### PR TITLE
Fix Glooko timezone handling across DST

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ To synchronize from Glooko use the following variables.
 * `CONNECT_SOURCE=glooko`
 * `CONNECT_GLOOKO_EMAIL=`
 * `CONNECT_GLOOKO_PASSWORD=`
+* `CONNECT_GLOOKO_TIMEZONE=` optional IANA timezone, for example `Europe/Prague`
 * `CONNECT_GLOOKO_TIMEZONE_OFFSET=0`
 * `CONNECT_GLOOKO_DEVICE_ID=` optional stable device identity
 * `CONNECT_GLOOKO_SERIAL_NUMBER=` optional stable serial number
@@ -195,7 +196,8 @@ default value for `CONNECT_GLOOKO_ENV` is `default`.
   `eu`, `development`, `production`, for `api.glooko.work`, and
   `externalapi.glooko.com`, respectively.
 * `CONNECT_GLOOKO_SERVER` the hostname server to use - `api.glooko.com` by `default`, `eu.api.glooko.com` for EU users, or a more specific regional host such as `de-fr.api.glooko.com`.
-* `CONNECT_GLOOKO_TIMEZONE_OFFSET` defines the time zone offset you are at from the UTC time zone, in hours
+* `CONNECT_GLOOKO_TIMEZONE` defines the IANA timezone used to convert Glooko local wall-clock timestamps, for example `Europe/Prague`. This handles daylight saving time based on each timestamp.
+* `CONNECT_GLOOKO_TIMEZONE_OFFSET` defines a fixed offset from UTC in hours and is retained for backward compatibility. `CONNECT_GLOOKO_TIMEZONE` takes precedence when both are configured.
 
 If both, `CONNECT_GLOOKO_SERVER` and `CONNECT_GLOOKO_ENV` are set, only
 `CONNECT_GLOOKO_SERVER` will be used.

--- a/lib/sources/glooko/convert.js
+++ b/lib/sources/glooko/convert.js
@@ -1,6 +1,8 @@
 var moment = require('moment');
 
-function generate_nightscout_treatments(batch, timestampDelta) {
+var timezone = require('./timezone');
+
+function generate_nightscout_treatments(batch, timestampDelta, timeZone) {
       // Snack Bolus
       // Meal Bolus
       // BG Check
@@ -113,9 +115,8 @@ function generate_nightscout_treatments(batch, timestampDelta) {
 
       //console.log(element);
       
-      var f_date = moment(element.pumpTimestamp);
       treatment.eventType = 'Meal Bolus';
-      treatment.eventTime = new Date(f_date + timestampDelta).toISOString( );
+      treatment.eventTime = timezone.timestampWithOffset(element.pumpTimestamp, timestampDelta, timeZone).toISOString( );
       treatment.insulin = element.insulinDelivered;
       treatment.carbs = element.carbsInput;
       treatment.notes = JSON.stringify(element);
@@ -159,9 +160,8 @@ function generate_nightscout_treatments(batch, timestampDelta) {
 
       //console.log(element);
       
-      var f_date = moment(element.pumpTimestamp);
       treatment.eventType = 'Temp Basal';
-      treatment.created_at = new Date(f_date + timestampDelta).toISOString( );
+      treatment.created_at = timezone.timestampWithOffset(element.pumpTimestamp, timestampDelta, timeZone).toISOString( );
       treatment.rate = element.rate;
       treatment.absolute = element.rate;
       treatment.duration = element.duration / 60;

--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -13,6 +13,7 @@ var url = require('url');
 var uid = require('uid');
 
 var helper = require('./convert');
+var timezone = require('./timezone');
 
 function makeUid (length) {
   var generator = typeof uid === 'function' ? uid : uid.uid;
@@ -140,9 +141,6 @@ function web_login_payload (opts, authenticityToken) {
     commit: 'Log in'
   });
 }
-function timestampWithOffset (timestamp, timestampDelta) {
-  return new Date(new Date(timestamp).getTime( ) + (timestampDelta || 0));
-}
 function readingValueInMgdl (reading) {
   var value = reading.value || reading.glucose || reading.sgv;
   if (!value || value <= 0) {
@@ -151,7 +149,7 @@ function readingValueInMgdl (reading) {
   // Glooko v2 CGM values are commonly encoded as mg/dL x 100.
   return value > 1000 ? Math.round(value / 100) : value;
 }
-function readingToEntry (timestampDelta, reading) {
+function readingToEntry (timestampDelta, timeZone, reading) {
   if (!reading || reading.softDeleted) {
     return null;
   }
@@ -160,7 +158,7 @@ function readingToEntry (timestampDelta, reading) {
   if (!timestamp || !sgv) {
     return null;
   }
-  var date = timestampWithOffset(timestamp, timestampDelta);
+  var date = timezone.timestampWithOffset(timestamp, timestampDelta, timeZone);
   return {
     type: 'sgv',
     device: 'nightscout-connect-glooko',
@@ -170,11 +168,11 @@ function readingToEntry (timestampDelta, reading) {
     direction: 'Flat'
   };
 }
-function generate_nightscout_entries (readings, timestampDelta) {
+function generate_nightscout_entries (readings, timestampDelta, timeZone) {
   if (!Array.isArray(readings)) {
     return [ ];
   }
-  return readings.map(readingToEntry.bind(null, timestampDelta)).filter(Boolean);
+  return readings.map(readingToEntry.bind(null, timestampDelta, timeZone)).filter(Boolean);
 }
 function meterUnitsFromProfile (profile) {
   var user = profile && (profile.currentUser || profile.currentPatient || profile.user || profile.patient);
@@ -195,7 +193,7 @@ function v3PointValueInMgdl (point, meterUnits) {
   }
   return convertDisplayGlucoseToMgdl(point.y, meterUnits);
 }
-function v3PointToEntry (timestampDelta, meterUnits, point) {
+function v3PointToEntry (timestampDelta, timeZone, meterUnits, point) {
   if (!point || point.calculated) {
     return null;
   }
@@ -204,7 +202,7 @@ function v3PointToEntry (timestampDelta, meterUnits, point) {
   if (!timestamp || !sgv) {
     return null;
   }
-  var date = timestampWithOffset(timestamp, timestampDelta);
+  var date = timezone.timestampWithOffset(timestamp, timestampDelta, timeZone);
   return {
     type: 'sgv',
     device: 'nightscout-connect-glooko-v3',
@@ -214,7 +212,7 @@ function v3PointToEntry (timestampDelta, meterUnits, point) {
     direction: 'Flat'
   };
 }
-function generate_v3_nightscout_entries (graph, timestampDelta, userProfile) {
+function generate_v3_nightscout_entries (graph, timestampDelta, timeZone, userProfile) {
   if (!graph || !graph.series) {
     return [ ];
   }
@@ -222,7 +220,7 @@ function generate_v3_nightscout_entries (graph, timestampDelta, userProfile) {
   return V3_CGM_SERIES
     .reduce((all, name) => all.concat(Array.isArray(graph.series[name]) ? graph.series[name] : [ ]), [ ])
     .sort((a, b) => (a.x || 0) - (b.x || 0))
-    .map(v3PointToEntry.bind(null, timestampDelta, meterUnits))
+    .map(v3PointToEntry.bind(null, timestampDelta, timeZone, meterUnits))
     .filter(Boolean);
 }
 function getGlookoCode (session) {
@@ -429,10 +427,10 @@ function glookoSource (opts, axios) {
       // TODO
       console.log('GLOOKO passing batch for transforming');
       //console.log("TODO TRANSFORM", batch);
-      var treatments = helper.generate_nightscout_treatments(batch, opts.glookoTimezoneOffset);
-      var entries = generate_nightscout_entries(batch && batch.readings, opts.glookoTimezoneOffset);
+      var treatments = helper.generate_nightscout_treatments(batch, opts.glookoTimezoneOffset, opts.glookoTimezone);
+      var entries = generate_nightscout_entries(batch && batch.readings, opts.glookoTimezoneOffset, opts.glookoTimezone);
       if (!entries.length && opts.glookoUseV3Graph) {
-        entries = generate_v3_nightscout_entries(batch && batch.v3Graph, opts.glookoTimezoneOffset, batch && batch.userProfile);
+        entries = generate_v3_nightscout_entries(batch && batch.v3Graph, opts.glookoTimezoneOffset, opts.glookoTimezone, batch && batch.userProfile);
       }
       return { entries, treatments };
     },
@@ -494,6 +492,7 @@ glookoSource.validate = function validate_inputs (input) {
     glookoServer: input.glookoServer,
     glookoEmail: input.glookoEmail,
     glookoPassword: input.glookoPassword,
+    glookoTimezone: input.glookoTimezone,
     glookoTimezoneOffset: offset,
     glookoDeviceId: input.glookoDeviceId || makeUid(16),
     glookoSerialNumber: input.glookoSerialNumber || makeUid(24),
@@ -508,6 +507,12 @@ glookoSource.validate = function validate_inputs (input) {
   }
   if (!config.glookoPassword) {
     errors.push({desc: "Glooko User Login Password is required. CONNECT_GLOOKO_PASSWORD must be the password for the Glooko User Login.", err: new Error('CONNECT_GLOOKO_PASSWORD') } );
+  }
+  if (!timezone.isValidTimezone(config.glookoTimezone)) {
+    errors.push({
+      desc: "CONNECT_GLOOKO_TIMEZONE must be a valid IANA timezone, for example Europe/Prague.",
+      err: new Error('CONNECT_GLOOKO_TIMEZONE')
+    });
   }
   ok = errors.length == 0;
   config.kind = ok ? 'glooko' : 'disabled';

--- a/lib/sources/glooko/timezone.js
+++ b/lib/sources/glooko/timezone.js
@@ -1,0 +1,71 @@
+function isValidTimezone (timeZone) {
+  if (!timeZone) {
+    return true;
+  }
+
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone }).format();
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+function timezoneOffsetAt (date, timeZone) {
+  var formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23'
+  });
+
+  var parts = formatter.formatToParts(date)
+    .reduce((result, part) => {
+      result[part.type] = part.value;
+      return result;
+    }, {});
+
+  var localAsUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    Number(parts.hour),
+    Number(parts.minute),
+    Number(parts.second),
+    date.getUTCMilliseconds()
+  );
+
+  return localAsUtc - date.getTime();
+}
+
+function timestampWithTimezone (timestamp, timeZone) {
+  var wallTime = new Date(timestamp);
+  var wallTimeMs = wallTime.getTime();
+
+  var offset = timezoneOffsetAt(wallTime, timeZone);
+  var result = new Date(wallTimeMs - offset);
+
+  var resolvedOffset = timezoneOffsetAt(result, timeZone);
+  if (resolvedOffset !== offset) {
+    result = new Date(wallTimeMs - resolvedOffset);
+  }
+
+  return result;
+}
+
+function timestampWithOffset (timestamp, timestampDelta, timeZone) {
+  if (timeZone) {
+    return timestampWithTimezone(timestamp, timeZone);
+  }
+
+  return new Date(new Date(timestamp).getTime() + (timestampDelta || 0));
+}
+
+module.exports = {
+  isValidTimezone,
+  timestampWithOffset
+};

--- a/test/glooko.test.js
+++ b/test/glooko.test.js
@@ -431,6 +431,178 @@ test('Glooko transform applies configured timezone offset to fake-UTC readings',
   assert.equal(result.entries[0].dateString, '2025-10-09T06:53:20.000Z');
 });
 
+test('Glooko validation carries configured IANA timezone', () => {
+  const result = glookoSource.validate({
+    glookoEmail: 'user@example.com',
+    glookoPassword: 'secret',
+    glookoTimezone: 'Europe/Prague'
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.config.glookoTimezone, 'Europe/Prague');
+});
+
+test('Glooko transform applies DST-aware timezone offset per timestamp', () => {
+  const source = glookoSource({
+    glookoEmail: 'user@example.com',
+    glookoPassword: 'secret',
+    glookoTimezone: 'Europe/Prague',
+    baseURL: 'https://eu.api.glooko.com'
+  }, fakeAxios(() => Promise.resolve({ data: {} })));
+
+  const result = source.transformData({
+    readings: [
+      { timestamp: '2026-01-15T08:53:20.000Z', value: 11000 },
+      { timestamp: '2026-07-15T08:53:20.000Z', value: 12000 }
+    ]
+  });
+
+  assert.equal(result.entries[0].dateString, '2026-01-15T07:53:20.000Z');
+  assert.equal(result.entries[1].dateString, '2026-07-15T06:53:20.000Z');
+});
+
+test('Glooko v3 graph transform applies DST-aware timezone to fake-UTC timestamps', () => {
+  const source = glookoSource({
+    glookoEmail: 'user@example.com',
+    glookoPassword: 'secret',
+    glookoTimezone: 'Europe/Prague',
+    glookoUseV3Graph: true,
+    baseURL: 'https://eu.api.glooko.com'
+  }, fakeAxios(() => Promise.resolve({ data: {} })));
+
+  const result = source.transformData({
+    readings: [],
+    v3Graph: {
+      series: {
+        cgmNormal: [
+          {
+            x: Date.parse('2026-07-15T08:53:20.000Z') / 1000,
+            timestamp: '2026-07-15T08:53:20.000Z',
+            value: 12000,
+            calculated: false
+          },
+          {
+            x: Date.parse('2026-01-15T08:53:20.000Z') / 1000,
+            value: 11000,
+            calculated: false
+          }
+        ]
+      }
+    }
+  });
+
+  assert.equal(result.entries[0].dateString, '2026-01-15T07:53:20.000Z');
+  assert.equal(result.entries[1].dateString, '2026-07-15T06:53:20.000Z');
+});
+
+test('Glooko IANA timezone takes precedence over fixed timezone offset', () => {
+  const source = glookoSource({
+    glookoEmail: 'user@example.com',
+    glookoPassword: 'secret',
+    glookoTimezone: 'Europe/Prague',
+    glookoTimezoneOffset: -3600000,
+    baseURL: 'https://eu.api.glooko.com'
+  }, fakeAxios(() => Promise.resolve({ data: {} })));
+
+  const result = source.transformData({
+    readings: [
+      { timestamp: '2026-07-15T08:53:20.000Z', value: 12000 }
+    ]
+  });
+
+  assert.equal(result.entries[0].dateString, '2026-07-15T06:53:20.000Z');
+});
+
+test('Glooko validation rejects invalid IANA timezone', () => {
+  const result = glookoSource.validate({
+    glookoEmail: 'user@example.com',
+    glookoPassword: 'secret',
+    glookoTimezone: 'Not/A_Timezone'
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.config.kind, 'disabled');
+  assert.ok(result.errors.some((error) => /timezone/i.test(error.desc)));
+});
+
+test('Glooko timezone conversion handles DST transition boundaries', () => {
+  const source = glookoSource({
+    glookoEmail: 'user@example.com',
+    glookoPassword: 'secret',
+    glookoTimezone: 'Europe/Prague',
+    baseURL: 'https://eu.api.glooko.com'
+  }, fakeAxios(() => Promise.resolve({ data: {} })));
+
+  const result = source.transformData({
+    readings: [
+      { timestamp: '2026-03-29T01:59:59.000Z', value: 11000 },
+      { timestamp: '2026-03-29T03:00:00.000Z', value: 12000 }
+    ]
+  });
+
+  assert.equal(result.entries[0].dateString, '2026-03-29T00:59:59.000Z');
+  assert.equal(result.entries[1].dateString, '2026-03-29T01:00:00.000Z');
+});
+
+test('Glooko pump treatments apply DST-aware timezone per timestamp', () => {
+  const source = glookoSource({
+    glookoEmail: 'user@example.com',
+    glookoPassword: 'secret',
+    glookoTimezone: 'Europe/Prague',
+    glookoTimezoneOffset: 0,
+    baseURL: 'https://eu.api.glooko.com'
+  }, fakeAxios(() => Promise.resolve({ data: {} })));
+
+  const result = source.transformData({
+    readings: [],
+    normalBoluses: [
+      {
+        pumpTimestamp: '2026-01-15T08:53:20.000Z',
+        insulinDelivered: 1.0,
+        carbsInput: 10
+      },
+      {
+        pumpTimestamp: '2026-07-15T08:53:20.000Z',
+        insulinDelivered: 1.5,
+        carbsInput: 15
+      }
+    ],
+    scheduledBasals: [
+      {
+        pumpTimestamp: '2026-07-15T09:00:00.000Z',
+        rate: 1.0,
+        duration: 1800
+      }
+    ]
+  });
+
+  const boluses = result.treatments.filter((item) => item.eventType === 'Meal Bolus');
+  const basals = result.treatments.filter((item) => item.eventType === 'Temp Basal');
+
+  assert.equal(boluses[0].eventTime, '2026-01-15T07:53:20.000Z');
+  assert.equal(boluses[1].eventTime, '2026-07-15T06:53:20.000Z');
+  assert.equal(basals[0].created_at, '2026-07-15T07:00:00.000Z');
+});
+
+test('Glooko pump treatments preserve configured fixed timezone offset', () => {
+  const source = glookoSource({
+    glookoEmail: 'user@example.com',
+    glookoPassword: 'secret',
+    glookoTimezoneOffset: -7200000,
+    baseURL: 'https://eu.api.glooko.com'
+  }, fakeAxios(() => Promise.resolve({ data: {} })));
+
+  const result = source.transformData({
+    readings: [],
+    normalBoluses: [{
+      pumpTimestamp: '2026-07-15T08:53:20.000Z',
+      insulinDelivered: 1
+    }]
+  });
+
+  assert.equal(result.treatments[0].eventTime, '2026-07-15T06:53:20.000Z');
+});
+
 test('Glooko transform tolerates missing readings', () => {
   const source = glookoSource({
     glookoEmail: 'user@example.com',


### PR DESCRIPTION
## Summary

Adds support for DST-aware Glooko timestamp conversion using an IANA timezone, while preserving the existing fixed-offset configuration for backward compatibility.

Fixes #10.

## Changes

* Adds `CONNECT_GLOOKO_TIMEZONE`, for example:

  * `CONNECT_GLOOKO_TIMEZONE=Europe/Prague`
* Calculates the applicable UTC offset separately for each timestamp, including historical data across DST boundaries.
* Keeps `CONNECT_GLOOKO_TIMEZONE_OFFSET` as a backward-compatible fixed-offset fallback.
* Gives `CONNECT_GLOOKO_TIMEZONE` precedence when both settings are configured.
* Applies the timezone conversion to:

  * v2 CGM readings
  * v3 graph CGM readings
  * currently fetched pump bolus and scheduled basal treatments
* Validates configured IANA timezone names.
* Does not change the Glooko graph query time range.

## Background

For the Glooko EU account used for testing, v3 graph timestamps behave as local wall-clock values encoded with a `Z` suffix. For example, a reading displayed by Glooko as `20:53 CEST` is returned as `2026-08-16T20:53:50.000Z`, requiring timezone context to convert it to the correct UTC instant (`18:53:50Z`).

The Glooko `/api/v3/session/users` response contains a `timezone` property, but it is `null` for both `currentUser` and `currentPatient` on the tested account, so the timezone cannot currently be reliably derived from Glooko itself.

## Testing

Added regression coverage for:

* winter and summer timestamps in the same batch
* DST transition boundaries
* v3 graph `timestamp` and `x` values
* invalid IANA timezone validation
* IANA timezone precedence over the legacy fixed offset
* pump bolus and scheduled basal treatments
* preservation of existing fixed-offset behavior

The full test suite passes.

The change was also tested against a real Glooko EU integration using `Europe/Prague` while deliberately configuring the legacy fixed offset as `1`. During CEST, entries were correctly converted using the 2-hour DST offset, confirming that the IANA timezone path was being used.

The behavior of Glooko timestamps during the repeated hour at the autumn DST transition has not yet been verified against real data.
