### PR TITLE
Fix Glooko v3 request parameters

### DIFF
--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -309,13 +309,13 @@ function glookoSource (opts, axios) {
       var minutes = 5 * maxCount;
       var lastUpdatedAt = last_glucose_at.toISOString( );
       var body = { };
-      var params = {
+      var v2Params = {
         lastGuid: Defaults.lastGuid,
         lastUpdatedAt,
         limit: maxCount,
       };
 
-      function fetcher (endpoint) {
+      function fetcher (endpoint, requestParams) {
         var headers = { ...default_headers };
         headers["Cookie"] = session.cookies;
         headers["Host"] = baseHost;
@@ -323,7 +323,7 @@ function glookoSource (opts, axios) {
         headers["Sec-Fetch-Mode"] = "cors";
         headers["Sec-Fetch-Site"] = "same-site";
         console.log('GLOOKO FETCHER LOADING', endpoint);
-        return http.get(endpoint, { headers, params })
+        return http.get(endpoint, { headers, params: requestParams === undefined ? v2Params : requestParams })
           .then((resp) => resp.data);
       }
 
@@ -399,14 +399,14 @@ function glookoSource (opts, axios) {
           }
           var patientCode = getGlookoCode(session);
           if (!patientCode) {
-            return fetcher('/api/v3/session/users')
+            return fetcher('/api/v3/session/users', {})
               .then((profile) => ({ ...some, userProfile: profile }))
               .then((withProfile) => {
                 var profileCode = withProfile.userProfile && (withProfile.userProfile.currentUser && withProfile.userProfile.currentUser.glookoCode || withProfile.userProfile.currentPatient && withProfile.userProfile.currentPatient.glookoCode);
                 if (!profileCode) {
                   return withProfile;
                 }
-                return fetcher(constructV3GraphUrl(profileCode, new Date(two_days_ago), new Date( )))
+                return fetcher(constructV3GraphUrl(profileCode, new Date(two_days_ago), new Date( )), {})
                   .then((v3Graph) => ({ ...withProfile, v3Graph }));
               })
               .catch((err) => {
@@ -414,7 +414,7 @@ function glookoSource (opts, axios) {
                 return some;
               });
           }
-          return fetcher(constructV3GraphUrl(patientCode, new Date(two_days_ago), new Date( )))
+          return fetcher(constructV3GraphUrl(patientCode, new Date(two_days_ago), new Date( )), {})
             .then((v3Graph) => ({ ...some, v3Graph }))
             .catch((err) => {
               console.log('GLOOKO V3 GRAPH FETCH FAILED', err && err.message);

--- a/test/glooko.test.js
+++ b/test/glooko.test.js
@@ -18,6 +18,21 @@ function fakeAxios (handler) {
   };
 }
 
+function assertHasV2SyncParams (call) {
+  assert.ok(call.options.params);
+  assert.ok(call.options.params.lastGuid);
+  assert.equal(typeof call.options.params.lastUpdatedAt, 'string');
+  assert.ok(call.options.params.limit > 0);
+}
+
+function assertHasNoV2SyncParams (call) {
+  const params = call.options && call.options.params || {};
+
+  assert.equal(params.lastGuid, undefined);
+  assert.equal(params.lastUpdatedAt, undefined);
+  assert.equal(params.limit, undefined);
+}
+
 test('Glooko validation supports default, EU, and explicit servers', () => {
   const common = {
     glookoEmail: 'user@example.com',
@@ -354,15 +369,19 @@ test('Glooko data fetch adds v3 graph fallback when v2 CGM readings are empty', 
     calls.push(call);
     assert.equal(call.options.headers.Host, 'de-fr.api.glooko.com');
     if (call.path.startsWith('/api/v2/pumps/scheduled_basals')) {
+      assertHasV2SyncParams(call);
       return Promise.resolve({ data: { scheduledBasals: [] } });
     }
     if (call.path.startsWith('/api/v2/pumps/normal_boluses')) {
+      assertHasV2SyncParams(call);
       return Promise.resolve({ data: { normalBoluses: [] } });
     }
     if (call.path.startsWith('/api/v2/cgm/readings')) {
+      assertHasV2SyncParams(call);
       return Promise.resolve({ data: { readings: [] } });
     }
     if (call.path.startsWith('/api/v3/graph/data')) {
+      assertHasNoV2SyncParams(call);
       assert.match(call.path, /series\[\]=cgmNormal/);
       assert.doesNotMatch(call.path, /series%5B%5D/);
       return Promise.resolve({ data: { series: { cgmNormal: [{ x: 1760000000, value: 12345 }] } } });
@@ -389,18 +408,23 @@ test('Glooko data fetch can resolve patient code from v3 session profile before 
   }, fakeAxios((call) => {
     calls.push(call);
     if (call.path.startsWith('/api/v2/pumps/scheduled_basals')) {
+      assertHasV2SyncParams(call);
       return Promise.resolve({ data: { scheduledBasals: [] } });
     }
     if (call.path.startsWith('/api/v2/pumps/normal_boluses')) {
+      assertHasV2SyncParams(call);
       return Promise.resolve({ data: { normalBoluses: [] } });
     }
     if (call.path.startsWith('/api/v2/cgm/readings')) {
+      assertHasV2SyncParams(call);
       return Promise.resolve({ data: { readings: [] } });
     }
     if (call.path === '/api/v3/session/users') {
+      assertHasNoV2SyncParams(call);
       return Promise.resolve({ data: { currentUser: { glookoCode: 'patient-from-profile' } } });
     }
     if (call.path.startsWith('/api/v3/graph/data')) {
+      assertHasNoV2SyncParams(call);
       assert.match(call.path, /patient=patient-from-profile/);
       return Promise.resolve({ data: { series: { cgmNormal: [{ x: 1760000000, value: 12345 }] } } });
     }


### PR DESCRIPTION
## Summary

Prevents Glooko v2 synchronization parameters from being sent to v3 endpoints.

Fixes #59.

## Problem

The Glooko `fetcher()` currently applies the same query parameters to all GET requests:

* `lastGuid`
* `lastUpdatedAt`
* `limit`

These parameters are used by the v2 synchronization endpoints, but Glooko v3 rejects them.

Affected endpoints include:

* `/api/v3/session/users`
* `/api/v3/graph/data`

Glooko responds with:

```text
HTTP 422
{"error":"found unpermitted parameters: :lastGuid, :lastUpdatedAt, :limit"}
```

## Changes

* Keeps the existing synchronization parameters as the default for v2 requests.
* Allows `fetcher()` to receive explicit request parameters.
* Calls the v3 session and graph endpoints without the v2-only synchronization parameters.
* Leaves the existing v3 graph request URL and time range unchanged.

## Testing

Regression tests verify that:

* v2 scheduled basal requests still receive `lastGuid`, `lastUpdatedAt`, and `limit`
* v2 normal bolus requests still receive them
* v2 CGM requests still receive them
* `/api/v3/session/users` does not receive them
* `/api/v3/graph/data` does not receive them

The full test suite passes.

The change was also tested against a real Glooko EU account using the current v3 graph fallback. The v2 CGM endpoint returned no readings, the v3 graph request completed successfully without HTTP 422, and the response produced 821 Nightscout CGM entries.
