### PR TITLE
Glooko: import pump events, alarms, scheduled basals and food (fixes #45)

### DIFF
--- a/GLOOKO-PUMP-EVENTS.md
+++ b/GLOOKO-PUMP-EVENTS.md
@@ -61,13 +61,25 @@ and raises the STOP timer from 5 minutes to 24 hours.
 
 ---
 
-## Known limitation
+## Deduplication
 
-Pump events and alarms are filtered against the same timestamp cursor as
-treatments. Glooko's sync lag is ~40 minutes, so an alarm that fires *before* a
-bolus but syncs *after* it will be skipped. The robust fix is to deduplicate on
-Glooko's own `guid` rather than a timestamp — which is what Taylor's
-independent `glooko-bridge` already does.
+Pump events and alarms are deduplicated on **Glooko's own `guid`**, not on a
+timestamp. Glooko's sync lag is around 40 minutes, so an event can arrive after
+a bolus that happened later than it — against a time cursor that event falls
+behind the mark and is skipped for good.
+
+Each generated treatment carries `glookoGuid`. The output layer seeds the known
+set from Nightscout at startup (45-day window) and adds to it as it posts, so a
+restart does not re-import everything inside the fetch window.
+
+Measured on a live instance: the first run after adopting this imported 80
+treatments (nothing carried a guid yet), the next run seeded 74 guids and
+imported 6, and the one after that imported 1 — a genuinely new bolus.
+
+⚠️ Event types the converter does not map — `prime_cannula`, `prime_tubing`,
+`pod_deactivated`, `pod_discarded` — are never stored, so they never enter the
+guid set and are re-examined every cycle. They produce no treatments, so this
+is log noise rather than a correctness problem.
 
 ## Nightscout configuration (not code)
 

--- a/GLOOKO-PUMP-EVENTS.md
+++ b/GLOOKO-PUMP-EVENTS.md
@@ -1,0 +1,89 @@
+# nightscout-connect patches
+
+Changes made to **nightscout-connect** (not Nightscout itself) to get Omnipod 5
+pod/sensor/reservoir changes and pump alarms out of Glooko and into Nightscout.
+
+`glooko-pump-events.patch` applies cleanly to a fresh checkout of
+`nightscout/nightscout-connect` **main**. 190 changed lines across three files.
+
+**Nightscout core is untouched.** Everything done there was environment
+variables in `docker-compose.yml` — listed at the bottom so they can be
+reproduced, but they are configuration, not code.
+
+---
+
+## What the patch does
+
+### `lib/sources/glooko/index.js`
+
+**Fetch pump events and alarms.** Adds `/api/v2/pumps/events` and
+`/api/v2/pumps/alarms`, which upstream never requests. Both carry data Glooko
+has always had — pod activations, reservoir changes, sensor changes, and the
+pump's own alarm log.
+
+⚠️ **They need their own query window.** The driver shares one `params` object
+whose `lastUpdatedAt` is pinned near *now* and whose `limit` collapses to
+roughly zero. Against these endpoints that returns an empty array, which looks
+exactly like "no data". `eventsFetcher()` uses a separate 14-day window.
+
+**DST-correct timestamps.** `CONNECT_GLOOKO_TIMEZONE` (e.g. `America/Toronto`)
+drives a per-timestamp `moment-timezone` conversion. The existing
+`CONNECT_GLOOKO_TIMEZONE_OFFSET` is a fixed hour offset that is right for half
+the year and silently an hour wrong for the other half. The offset remains as a
+fallback.
+
+**Cursor fix.** `last_mills` tracked `last_known.entries`, which Dexcom Share
+rewrites every five minutes — pinning the cursor to now and collapsing `limit`.
+Now tracks `last_known.treatments`.
+
+### `lib/sources/glooko/convert.js`
+
+Maps Glooko's own event types onto Nightscout's:
+
+| Glooko `type` | Nightscout eventType | feeds |
+|---|---|---|
+| `pod_activating` | `Site Change` | CAGE |
+| `cgm_sensor_change` | `Sensor Start` | SAGE |
+| `reservoir_change` | `Insulin Change` | IAGE |
+
+Alarms become `Note` treatments — never `Announcement`, so Nightscout draws
+them on the graph without raising notifications. `alarm_type` is always null in
+Glooko's payload; the machine-readable code is in **`value`**
+(`omnipod_exit_close_loop`, `dexcom_signal_loss`, …).
+
+⚠️ Uses `eventTime`, not `created_at`. Nightscout only derives `mills` from the
+former, and clients need `mills` to age a treatment.
+
+### `commands/forever.js`
+
+Builds the driver config through `driver.validate()` so `baseURL` is populated,
+and raises the STOP timer from 5 minutes to 24 hours.
+
+---
+
+## Known limitation
+
+Pump events and alarms are filtered against the same timestamp cursor as
+treatments. Glooko's sync lag is ~40 minutes, so an alarm that fires *before* a
+bolus but syncs *after* it will be skipped. The robust fix is to deduplicate on
+Glooko's own `guid` rather than a timestamp — which is what Taylor's
+independent `glooko-bridge` already does.
+
+## Nightscout configuration (not code)
+
+```yaml
+BG_LOW: "55"            # mg/dL regardless of DISPLAY_UNITS
+BG_TARGET_BOTTOM: "70"
+BG_TARGET_TOP: "198"
+BG_HIGH: "260"
+SHOW_PLUGINS: careportal basal iob cob cage sage iage bolus dbsize
+CAGE_INFO/WARN/URGENT: 60 / 68 / 72      # Omnipod 72h
+IAGE_INFO/WARN/URGENT: 60 / 68 / 72
+SAGE_INFO/WARN/URGENT: 216 / 236 / 240   # Dexcom G7 10 days
+CONNECT_GLOOKO_TIMEZONE: America/Toronto
+THEME: colors
+```
+
+⚠️ `SHOW_PLUGINS` is only a *default* for browsers that have never saved
+settings. Once a browser saves any setting its local list wins permanently —
+use **Settings → "Reset, and use defaults"** in each browser after changing it.

--- a/GLOOKO-PUMP-EVENTS.md
+++ b/GLOOKO-PUMP-EVENTS.md
@@ -1,14 +1,13 @@
-# nightscout-connect patches
+# Glooko: pump events, alarms and guid deduplication
 
-Changes made to **nightscout-connect** (not Nightscout itself) to get Omnipod 5
-pod/sensor/reservoir changes and pump alarms out of Glooko and into Nightscout.
+Gets Omnipod 5 pod, sensor and reservoir changes, plus the pump's own alarm log,
+out of Glooko and into Nightscout — so the `cage`, `sage` and `iage` plugins
+populate from the pump's own record instead of needing someone to log changes by
+hand in careportal.
 
-`glooko-pump-events.patch` applies cleanly to a fresh checkout of
-`nightscout/nightscout-connect` **main**. 190 changed lines across three files.
-
-**Nightscout core is untouched.** Everything done there was environment
-variables in `docker-compose.yml` — listed at the bottom so they can be
-reproduced, but they are configuration, not code.
+Nightscout core is untouched; this is entirely within the Glooko source driver,
+the converter and the Nightscout output. Enabling the resulting plugins is
+ordinary Nightscout configuration and is out of scope here.
 
 ---
 
@@ -26,7 +25,7 @@ whose `lastUpdatedAt` is pinned near *now* and whose `limit` collapses to
 roughly zero. Against these endpoints that returns an empty array, which looks
 exactly like "no data". `eventsFetcher()` uses a separate 14-day window.
 
-**DST-correct timestamps.** `CONNECT_GLOOKO_TIMEZONE` (e.g. `America/Toronto`)
+**DST-correct timestamps.** `CONNECT_GLOOKO_TIMEZONE` (e.g. `Europe/Prague`)
 drives a per-timestamp `moment-timezone` conversion. The existing
 `CONNECT_GLOOKO_TIMEZONE_OFFSET` is a fixed hour offset that is right for half
 the year and silently an hour wrong for the other half. The offset remains as a
@@ -81,21 +80,13 @@ imported 6, and the one after that imported 1 — a genuinely new bolus.
 guid set and are re-examined every cycle. They produce no treatments, so this
 is log noise rather than a correctness problem.
 
-## Nightscout configuration (not code)
+## Note on enabling the plugins
 
-```yaml
-BG_LOW: "55"            # mg/dL regardless of DISPLAY_UNITS
-BG_TARGET_BOTTOM: "70"
-BG_TARGET_TOP: "198"
-BG_HIGH: "260"
-SHOW_PLUGINS: careportal basal iob cob cage sage iage bolus dbsize
-CAGE_INFO/WARN/URGENT: 60 / 68 / 72      # Omnipod 72h
-IAGE_INFO/WARN/URGENT: 60 / 68 / 72
-SAGE_INFO/WARN/URGENT: 216 / 236 / 240   # Dexcom G7 10 days
-CONNECT_GLOOKO_TIMEZONE: America/Toronto
-THEME: colors
-```
+The wear-time plugins (`cage`, `sage`, `iage`) have to be in both `ENABLE` and
+`SHOW_PLUGINS`, and pod/sensor lifetimes differ from Nightscout's defaults — an
+Omnipod runs 72 h against a default that assumes a 3-day infusion set, and a
+Dexcom G7 runs 10 days against a default that assumes a 7-day G6.
 
-⚠️ `SHOW_PLUGINS` is only a *default* for browsers that have never saved
-settings. Once a browser saves any setting its local list wins permanently —
-use **Settings → "Reset, and use defaults"** in each browser after changing it.
+`SHOW_PLUGINS` is only a *default* for browsers that have never saved settings.
+Once a browser saves any setting its local list wins permanently — use
+**Settings -> "Reset, and use defaults"** in that browser after changing it.

--- a/commands/forever.js
+++ b/commands/forever.js
@@ -43,7 +43,9 @@ function main (argv) {
   var output = { name: 'nightscout', url: argv.nightscoutEndpoint, apiSecret: argv.apiSecret };
   console.log("CONFIGURED OUTPUT", output);
   var input = Object.assign({}, argv, { kind: argv.source, url: argv.sourceEndpoint, apiSecret: argv.sourceApiSecret });
-  console.log("CONFIGURED INPUT", input);
+  // argv now carries every CONNECT_* env var, credentials included, so log the
+  // shape rather than the values.
+  console.log("CONFIGURED INPUT", { kind: input.kind, url: input.url, keys: Object.keys(input).length });
 
   var things = sidecarLoop(input, output);
   console.log(things);

--- a/commands/forever.js
+++ b/commands/forever.js
@@ -18,8 +18,11 @@ function sidecarLoop (input, output) {
   // select an available input source implementation based on env
   // variables/config
   var driver = sources(input);
-  console.log("INPUT PARAMS", input);
-  var impl = driver(input, axios);
+  var _v = driver.validate ? driver.validate(input) : null;
+  if (_v && !_v.ok) console.log("VALIDATION ERRORS", _v.errors.map(function(e){return e.desc;}));
+  var _opts = (_v && _v.ok) ? _v.config : input;
+  console.log("DRIVER OPTS baseURL:", _opts.baseURL, "authMode:", _opts.glookoAuthMode);
+  var impl = driver(_opts, axios);
   // var impl = testImpl.fakeFrame({ }, axios);
 
   impl.generate_driver(make);
@@ -39,7 +42,7 @@ function main (argv) {
   // 
   var output = { name: 'nightscout', url: argv.nightscoutEndpoint, apiSecret: argv.apiSecret };
   console.log("CONFIGURED OUTPUT", output);
-  var input = { kind: argv.source, url: argv.sourceEndpoint, apiSecret: argv.sourceApiSecret };
+  var input = Object.assign({}, argv, { kind: argv.source, url: argv.sourceEndpoint, apiSecret: argv.sourceApiSecret });
   console.log("CONFIGURED INPUT", input);
 
   var things = sidecarLoop(input, output);
@@ -49,7 +52,7 @@ function main (argv) {
   actor.send({type: 'START'});
   setTimeout(( ) => {
   actor.send({type: 'STOP'});
-  }, 60000 * 5);
+  }, 60000 * 60 * 24);
 
 }
 

--- a/lib/outputs/nightscout.js
+++ b/lib/outputs/nightscout.js
@@ -51,9 +51,10 @@ function nightscoutRestAPI (config, axios) {
   // cursor and be skipped for good.
   function remember_guids (data) {
     if (!bookmark) return;
-    if (!bookmark.seenGuids) bookmark.seenGuids = [ ];
     (data || []).forEach(function (t) {
-      if (t && t.glookoGuid && bookmark.seenGuids.indexOf(t.glookoGuid) < 0) {
+      if (!t || !t.glookoGuid) { return; }
+      if (!bookmark.seenGuids) { bookmark.seenGuids = [ ]; }
+      if (bookmark.seenGuids.indexOf(t.glookoGuid) < 0) {
         bookmark.seenGuids.push(t.glookoGuid);
       }
     });
@@ -172,11 +173,16 @@ function nightscoutRestAPI (config, axios) {
           'find[created_at][$gte]': new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString()
         }, headers
       }).then((resp) => {
-        bookmark.seenGuids = (resp.data || [])
+        // Only carried on the bookmark when a source actually uses guids, so the
+        // persisted shape is unchanged for sources that do not.
+        var guids = (resp.data || [])
           .map(function (t) { return t.glookoGuid; })
           .filter(Boolean);
-        console.log("SEEDED", bookmark.seenGuids.length, "known glooko guids");
-      }).catch(function ( ) { bookmark.seenGuids = [ ]; }),
+        if (guids.length) {
+          bookmark.seenGuids = guids;
+          console.log("SEEDED", guids.length, "known source guids");
+        }
+      }).catch(function ( ) { }),
     ]).then(( ) => {
       console.log("UPDATED BOOKMARKS", bookmark);
     }).catch((err) => {

--- a/lib/outputs/nightscout.js
+++ b/lib/outputs/nightscout.js
@@ -46,12 +46,26 @@ function nightscoutRestAPI (config, axios) {
     });
   }
 
+  // Deduplicating on Glooko's own guid instead of a timestamp: an event that
+  // fires before a bolus but syncs after it would otherwise fall behind the
+  // cursor and be skipped for good.
+  function remember_guids (data) {
+    if (!bookmark) return;
+    if (!bookmark.seenGuids) bookmark.seenGuids = [ ];
+    (data || []).forEach(function (t) {
+      if (t && t.glookoGuid && bookmark.seenGuids.indexOf(t.glookoGuid) < 0) {
+        bookmark.seenGuids.push(t.glookoGuid);
+      }
+    });
+  }
+
   function record_treatments (data) {
     if (!data.length) {
       return Promise.resolve( );
     }
     var headers = { 'API-SECRET': apiHash };
     return http.post('/api/v1/treatments.json', data, { headers }).then((resp) => {
+      remember_guids(data);
       console.log("RECORDED BATCH, total treatments", resp.data.length);
       return resp.data;
     }).catch((err) => {
@@ -150,6 +164,19 @@ function nightscoutRestAPI (config, axios) {
       http.get('/api/v1/profile.json', { params: query, headers }).then((resp) => {
         bookmark.profiles = newestDate(resp.data, 'created_at') || bookmark.profiles;
       }),
+      // Seed the guid set from what is already stored. Without this a restart
+      // would re-import every pump event inside the fetch window.
+      http.get('/api/v1/treatments.json', {
+        params: {
+          count: 500,
+          'find[created_at][$gte]': new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString()
+        }, headers
+      }).then((resp) => {
+        bookmark.seenGuids = (resp.data || [])
+          .map(function (t) { return t.glookoGuid; })
+          .filter(Boolean);
+        console.log("SEEDED", bookmark.seenGuids.length, "known glooko guids");
+      }).catch(function ( ) { bookmark.seenGuids = [ ]; }),
     ]).then(( ) => {
       console.log("UPDATED BOOKMARKS", bookmark);
     }).catch((err) => {

--- a/lib/sources/glooko/convert.js
+++ b/lib/sources/glooko/convert.js
@@ -1,6 +1,19 @@
 var moment = require('moment');
+var momentTz = null;
+try { momentTz = require('moment-timezone'); } catch (e) { momentTz = null; }
 
-function generate_nightscout_treatments(batch, timestampDelta) {
+// Glooko stamps pump-LOCAL wall clock and then mislabels it with a "Z";
+// pumpTimestampUtcOffset:"+00:00" is a lie. Converting through the pump's IANA
+// zone handles DST automatically. A fixed hour offset does not - it is right
+// for half the year and silently an hour wrong for the other half.
+function pumpToUtc (ts, timestampDelta, timezone) {
+  if (timezone && momentTz && momentTz.tz.zone(timezone)) {
+    return momentTz.tz(String(ts).replace(/Z$/, ''), timezone).toDate( );
+  }
+  return new Date(moment(ts) + (timestampDelta || 0));
+}
+
+function generate_nightscout_treatments(batch, timestampDelta, timezone) {
       // Snack Bolus
       // Meal Bolus
       // BG Check
@@ -115,7 +128,7 @@ function generate_nightscout_treatments(batch, timestampDelta) {
       
       var f_date = moment(element.pumpTimestamp);
       treatment.eventType = 'Meal Bolus';
-      treatment.eventTime = new Date(f_date + timestampDelta).toISOString( );
+      treatment.eventTime = pumpToUtc(element.pumpTimestamp, timestampDelta, timezone).toISOString( );
       treatment.insulin = element.insulinDelivered;
       treatment.carbs = element.carbsInput;
       treatment.notes = JSON.stringify(element);
@@ -161,12 +174,89 @@ function generate_nightscout_treatments(batch, timestampDelta) {
       
       var f_date = moment(element.pumpTimestamp);
       treatment.eventType = 'Temp Basal';
-      treatment.created_at = new Date(f_date + timestampDelta).toISOString( );
+      treatment.created_at = pumpToUtc(element.pumpTimestamp, timestampDelta, timezone).toISOString( );
       treatment.rate = element.rate;
       treatment.absolute = element.rate;
       treatment.duration = element.duration / 60;
       treatment.notes = JSON.stringify(element);
       //treatment.eventTime = f_date.toISOString( );
+      treatments.push(treatment);
+    })
+  }
+
+  // Pod and reservoir events, straight from the pump's own record - this is
+  // what feeds Nightscout's CAGE/IAGE counters. pod_activating is the moment
+  // the new pod starts, which is what "site change" means for Omnipod.
+  const pumpEvents = batch.pumpEvents;
+  if (pumpEvents) {
+    const EVENT_MAP = {
+      pod_activating: 'Site Change',
+      reservoir_change: 'Insulin Change',
+      cgm_sensor_change: 'Sensor Start'
+    };
+    pumpEvents.forEach(function (element) {
+      const eventType = EVENT_MAP[element.type];
+      if (!eventType) { return; }
+      var treatment = {};
+      var f_date = moment(element.pumpTimestamp);
+      treatment.eventType = eventType;
+      // eventTime, not created_at - Nightscout only derives `mills` from the
+      // former, and clients rely on mills to age a treatment
+      treatment.eventTime = pumpToUtc(element.pumpTimestamp, timestampDelta, timezone).toISOString( );
+      treatment.notes = JSON.stringify(element);
+      treatments.push(treatment);
+    })
+  }
+
+  // Glooko alarms. `alarm_type` is always null - the machine-readable code
+  // lives in `value`. Imported as Note (never Announcement) so they land on
+  // the graph and in the log WITHOUT Nightscout raising notifications for
+  // them: this is a record, not an alerting system.
+  const ALARM_TEXT = {
+    // device health - nothing else surfaces these
+    omnipod_exit_close_loop: 'Left automated mode',
+    omnipod_twelve_missing_egv: 'Pump lost CGM feed',
+    omnipod_low_reservoir: 'Low reservoir',
+    omnipod_pod_expiration: 'Pod expired',
+    omnipod_pod_expiration_imminent: 'Pod expiring soon',
+    omnipod_pod_expire_at_user_set_time: 'Pod expiry reminder',
+    omnipod_pump_expired: 'Pod expired',
+    dexcom_signal_loss: 'Sensor signal lost',
+    dexcom_brief_sensor_issue: 'Brief sensor issue',
+    // glucose thresholds - Dexcom Follow already alarms on these, so they are
+    // here only to be drawn on the graph
+    dexcom_low_glucose_alert: 'Low glucose',
+    dexcom_high_glucose_alert: 'High glucose',
+    dexcom_urgent_low_alert: 'Urgent low',
+    dexcom_urgent_low_soon: 'Urgent low predicted',
+    dexcom_falling_fast_alert: 'Falling fast',
+    dexcom_rising_fast_alert: 'Rising fast',
+    omnipod_urgent_low_glucose: 'Urgent low (pump)'
+  };
+  const DEVICE_CODES = {
+    omnipod_exit_close_loop: 1, omnipod_twelve_missing_egv: 1,
+    omnipod_low_reservoir: 1, omnipod_pod_expiration: 1,
+    omnipod_pod_expiration_imminent: 1, omnipod_pod_expire_at_user_set_time: 1,
+    omnipod_pump_expired: 1, dexcom_signal_loss: 1,
+    dexcom_brief_sensor_issue: 1
+  };
+  const pumpAlarms = batch.pumpAlarms;
+  if (pumpAlarms) {
+    pumpAlarms.forEach(function (a) {
+      if (!a.value) { return; }
+      var text = ALARM_TEXT[a.value] || String(a.value).replace(/_/g, ' ');
+      var treatment = {};
+      treatment.eventType = 'Note';
+      treatment.eventTime = pumpToUtc(a.pump_timestamp, timestampDelta, timezone).toISOString( );
+      treatment.notes = text;
+      treatment.enteredBy = 'glooko-alarm';
+      // parsed by the display: severity, whether it is a device fault, and the
+      // raw code so an unmapped one is still identifiable
+      treatment.glookoAlarm = {
+        code: a.value,
+        severity: a.alarm_severity || 'alert',
+        device: DEVICE_CODES[a.value] ? true : false
+      };
       treatments.push(treatment);
     })
   }

--- a/lib/sources/glooko/convert.js
+++ b/lib/sources/glooko/convert.js
@@ -27,7 +27,7 @@ function generate_nightscout_treatments(batch, timestampDelta, timezone) {
   const foods = batch.foods;
   const insulins = batch.insulins;
   const pumpBoluses = batch.normalBoluses;
-  const scheduledBasals = batch.scheduledBasals;
+  const scheduledBasals = batch.wideBasals || batch.scheduledBasals;
   
   var treatments = []
   
@@ -177,7 +177,8 @@ function generate_nightscout_treatments(batch, timestampDelta, timezone) {
       treatment.created_at = pumpToUtc(element.pumpTimestamp, timestampDelta, timezone).toISOString( );
       treatment.rate = element.rate;
       treatment.absolute = element.rate;
-      treatment.duration = element.duration / 60;
+      treatment.duration = Math.round(element.duration / 6) / 10;  // seconds -> minutes
+      treatment.glookoGuid = element.guid;
       treatment.notes = JSON.stringify(element);
       //treatment.eventTime = f_date.toISOString( );
       treatments.push(treatment);
@@ -259,6 +260,27 @@ function generate_nightscout_treatments(batch, timestampDelta, timezone) {
         severity: a.alarm_severity || 'alert',
         device: DEVICE_CODES[a.value] ? true : false
       };
+      treatments.push(treatment);
+    })
+  }
+
+  // Logged food. Deliberately a Note and NOT a carb treatment: the bolus
+  // already carries carbsInput for the same meal, and a second carb entry
+  // would double-count into COB. This adds what was eaten, not how much.
+  const glookoFoods = batch.glookoFoods;
+  if (glookoFoods) {
+    glookoFoods.forEach(function (f) {
+      if (!f.name) { return; }
+      var parts = [];
+      if (f.carbs)   parts.push(Math.round(f.carbs) + 'g carb');
+      if (f.protein) parts.push(Math.round(f.protein) + 'g protein');
+      if (f.fat)     parts.push(Math.round(f.fat) + 'g fat');
+      var treatment = {};
+      treatment.eventType = 'Note';
+      treatment.eventTime = pumpToUtc(f.timestamp, timestampDelta, timezone).toISOString( );
+      treatment.notes = f.name + (parts.length ? ' (' + parts.join(', ') + ')' : '');
+      treatment.enteredBy = 'glooko-food';
+      treatment.glookoGuid = f.guid;
       treatments.push(treatment);
     })
   }

--- a/lib/sources/glooko/convert.js
+++ b/lib/sources/glooko/convert.js
@@ -203,6 +203,7 @@ function generate_nightscout_treatments(batch, timestampDelta, timezone) {
       // eventTime, not created_at - Nightscout only derives `mills` from the
       // former, and clients rely on mills to age a treatment
       treatment.eventTime = pumpToUtc(element.pumpTimestamp, timestampDelta, timezone).toISOString( );
+      treatment.glookoGuid = element.guid;
       treatment.notes = JSON.stringify(element);
       treatments.push(treatment);
     })
@@ -250,6 +251,7 @@ function generate_nightscout_treatments(batch, timestampDelta, timezone) {
       treatment.eventTime = pumpToUtc(a.pump_timestamp, timestampDelta, timezone).toISOString( );
       treatment.notes = text;
       treatment.enteredBy = 'glooko-alarm';
+      treatment.glookoGuid = a.guid;
       // parsed by the display: severity, whether it is a device fault, and the
       // raw code so an unmapped one is still identifiable
       treatment.glookoAlarm = {

--- a/lib/sources/glooko/convert.js
+++ b/lib/sources/glooko/convert.js
@@ -283,6 +283,44 @@ function generate_nightscout_treatments(batch, timestampDelta, timezone) {
       treatment.glookoGuid = f.guid;
       treatments.push(treatment);
     })
+
+    // Compare what was logged against what was actually dosed for. These are
+    // two different numbers for one meal, and the gap is the interesting part:
+    // it is invisible in either record alone and shows up later as an
+    // unexplained post-meal high.
+    var boluses = batch.correlationBoluses || batch.normalBoluses || [];
+    var WINDOW = 20 * 60 * 1000;
+    var clusters = [];
+    glookoFoods.slice().sort(function (a, b) {
+      return new Date(a.timestamp) - new Date(b.timestamp);
+    }).forEach(function (f) {
+      var t = new Date(f.timestamp).getTime();
+      var last = clusters[clusters.length - 1];
+      if (last && t - last.last <= WINDOW) {
+        last.carbs += (f.carbs || 0); last.last = t; last.names.push(f.name);
+      } else {
+        clusters.push({ first: t, last: t, carbs: (f.carbs || 0), names: [f.name], guid: f.guid });
+      }
+    });
+    clusters.forEach(function (cl) {
+      var best = null, bestGap = Infinity;
+      boluses.forEach(function (b) {
+        if (!b.carbsInput || !b.pumpTimestamp) { return; }
+        var gap = Math.abs(new Date(b.pumpTimestamp).getTime( ) - cl.first);
+        if (gap < bestGap && gap <= WINDOW) { bestGap = gap; best = b; }
+      });
+      if (!best) { return; }
+      var logged = Math.round(cl.carbs), dosed = Math.round(best.carbsInput);
+      if (Math.abs(logged - dosed) < 10) { return; }   // rounding, not a gap
+      var t2 = {};
+      t2.eventType = 'Note';
+      t2.eventTime = pumpToUtc(best.pumpTimestamp, timestampDelta, timezone).toISOString( );
+      t2.notes = 'Carb gap: bolused for ' + dosed + 'g, logged ' + logged + 'g ('
+               + (logged > dosed ? (logged - dosed) + 'g short' : (dosed - logged) + 'g over') + ')';
+      t2.enteredBy = 'glooko-carbgap';
+      t2.glookoGuid = 'carbgap-' + cl.guid;
+      treatments.push(t2);
+    });
   }
 
   console.log('GLOOKO data transformation complete, returning', treatments.length, 'treatments');

--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -413,6 +413,7 @@ function glookoSource (opts, axios) {
             eventsFetcher(Defaults.PumpAlarms),
             eventsFetcher(Defaults.LatestPumpBasals),
             eventsFetcher(Defaults.GlookoFoods),
+            eventsFetcher(Defaults.LatestPumpBolus),
             //fetcher(constructUrl(Defaults.PumpSettings))
           ]
         : [
@@ -422,7 +423,8 @@ function glookoSource (opts, axios) {
             Promise.resolve({ events: [] }),
             Promise.resolve({ alarms: [] }),
             Promise.resolve({ scheduledBasals: [] }),
-            Promise.resolve({ foods: [] })
+            Promise.resolve({ foods: [] }),
+            Promise.resolve({ normalBoluses: [] })
           ];
 
       return Promise.all(v2Fetches).then(function (results) {
@@ -448,8 +450,10 @@ function glookoSource (opts, axios) {
             glookoFoods: ((results[6] && results[6].foods) || [ ]).filter(function (f) {
               if (!f || f.softDeleted || !f.timestamp || !f.guid) { return false; }
               return !seen_guids.has(f.guid);
-            })
-            //settings: results[4].pumpSettings
+            }),
+            // not imported - only used to compare logged food against what was
+            // actually dosed for
+            correlationBoluses: ((results[7] && results[7].normalBoluses) || [ ])
          };
          if (some.pumpAlarms && some.pumpAlarms.length) {
            console.log('GLOOKO new alarms:',

--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -315,6 +315,12 @@ function glookoSource (opts, axios) {
       var maxCount = Math.ceil(((new Date( )).getTime( ) - last_mills) / (1000 * 60 * 5));
       var minutes = 5 * maxCount;
       var lastUpdatedAt = last_glucose_at.toISOString( );
+      // Glooko's own guid, not a timestamp: sync lag means an event can arrive
+      // after a bolus that happened later, and a time cursor would skip it.
+      // Seeded from Nightscout at startup and topped up as we post, so a
+      // restart does not re-import the whole window.
+      var seen_guids = new Set((last_known && last_known.seenGuids) || [ ]);
+
       var body = { };
       var params = {
         lastGuid: Defaults.lastGuid,
@@ -423,14 +429,12 @@ function glookoSource (opts, axios) {
             normalBoluses: results[1].normalBoluses,
             readings: results[2].readings,
             pumpEvents: ((results[3] && results[3].events) || [ ]).filter(function (e) {
-              if (!e || e.softDeleted || !e.pumpTimestamp) { return false; }
-              var when = new Date(e.pumpTimestamp).getTime( ) + (opts.glookoTimezoneOffset || 0);
-              return when > last_mills;
+              if (!e || e.softDeleted || !e.pumpTimestamp || !e.guid) { return false; }
+              return !seen_guids.has(e.guid);
             }),
             pumpAlarms: ((results[4] && results[4].alarms) || [ ]).filter(function (a) {
-              if (!a || a.soft_deleted || a.duplicate || !a.pump_timestamp) { return false; }
-              var when = new Date(a.pump_timestamp).getTime( ) + (opts.glookoTimezoneOffset || 0);
-              return when > last_mills;
+              if (!a || a.soft_deleted || a.duplicate || !a.pump_timestamp || !a.guid) { return false; }
+              return !seen_guids.has(a.guid);
             })
             //settings: results[4].pumpSettings
          };

--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -48,6 +48,7 @@ var Defaults = {
 , PumpSettings: '/api/v2/external/pumps/settings'
 , PumpEvents: '/api/v2/pumps/events'
 , PumpAlarms: '/api/v2/pumps/alarms'
+, GlookoFoods: '/api/v2/foods'
 , V3GraphData: '/api/v3/graph/data'
 , v3API: '/api/v3/graph/data?patient=_PATIENT_&startDate=_STARTDATE_&endDate=_ENDDATE_&series[]=automaticBolus&series[]=basalBarAutomated&series[]=basalBarAutomatedMax&series[]=basalBarAutomatedSuspend&series[]=basalLabels&series[]=basalModulation&series[]=bgAbove400&series[]=bgAbove400Manual&series[]=bgHigh&series[]=bgHighManual&series[]=bgLow&series[]=bgLowManual&series[]=bgNormal&series[]=bgNormalManual&series[]=bgTargets&series[]=carbNonManual&series[]=cgmCalibrationHigh&series[]=cgmCalibrationLow&series[]=cgmCalibrationNormal&series[]=cgmHigh&series[]=cgmLow&series[]=cgmNormal&series[]=deliveredBolus&series[]=deliveredBolus&series[]=extendedBolusStep&series[]=extendedBolusStep&series[]=gkCarb&series[]=gkInsulin&series[]=gkInsulin&series[]=gkInsulinBasal&series[]=gkInsulinBolus&series[]=gkInsulinOther&series[]=gkInsulinPremixed&series[]=injectionBolus&series[]=injectionBolus&series[]=interruptedBolus&series[]=interruptedBolus&series[]=lgsPlgs&series[]=overrideAboveBolus&series[]=overrideAboveBolus&series[]=overrideBelowBolus&series[]=overrideBelowBolus&series[]=pumpAdvisoryAlert&series[]=pumpAlarm&series[]=pumpBasaliqAutomaticMode&series[]=pumpBasaliqManualMode&series[]=pumpCamapsAutomaticMode&series[]=pumpCamapsBluetoothTurnedOffMode&series[]=pumpCamapsBoostMode&series[]=pumpCamapsDailyTotalInsulinExceededMode&series[]=pumpCamapsDepoweredMode&series[]=pumpCamapsEaseOffMode&series[]=pumpCamapsExtendedBolusNotAllowedMode&series[]=pumpCamapsManualMode&series[]=pumpCamapsNoCgmMode&series[]=pumpCamapsNoPumpConnectivityMode&series[]=pumpCamapsPumpDeliverySuspendedMode&series[]=pumpCamapsUnableToProceedMode&series[]=pumpControliqAutomaticMode&series[]=pumpControliqExerciseMode&series[]=pumpControliqManualMode&series[]=pumpControliqSleepMode&series[]=pumpGenericAutomaticMode&series[]=pumpGenericManualMode&series[]=pumpOp5AutomaticMode&series[]=pumpOp5HypoprotectMode&series[]=pumpOp5LimitedMode&series[]=pumpOp5ManualMode&series[]=reservoirChange&series[]=scheduledBasal&series[]=setSiteChange&series[]=suggestedBolus&series[]=suggestedBolus&series[]=suspendBasal&series[]=temporaryBasal&series[]=unusedScheduledBasal&locale=en-GB'
 // ?sessionID=e59c836f-5aeb-4b95-afa2-39cf2769fede&minutes=1440&maxCount=1"
@@ -410,6 +411,8 @@ function glookoSource (opts, axios) {
             fetcher(cgmReadingsUrl),
             eventsFetcher(Defaults.PumpEvents),
             eventsFetcher(Defaults.PumpAlarms),
+            eventsFetcher(Defaults.LatestPumpBasals),
+            eventsFetcher(Defaults.GlookoFoods),
             //fetcher(constructUrl(Defaults.PumpSettings))
           ]
         : [
@@ -417,7 +420,9 @@ function glookoSource (opts, axios) {
             Promise.resolve({ normalBoluses: [] }),
             Promise.resolve({ readings: [] }),
             Promise.resolve({ events: [] }),
-            Promise.resolve({ alarms: [] })
+            Promise.resolve({ alarms: [] }),
+            Promise.resolve({ scheduledBasals: [] }),
+            Promise.resolve({ foods: [] })
           ];
 
       return Promise.all(v2Fetches).then(function (results) {
@@ -435,6 +440,14 @@ function glookoSource (opts, axios) {
             pumpAlarms: ((results[4] && results[4].alarms) || [ ]).filter(function (a) {
               if (!a || a.soft_deleted || a.duplicate || !a.pump_timestamp || !a.guid) { return false; }
               return !seen_guids.has(a.guid);
+            }),
+            wideBasals: ((results[5] && results[5].scheduledBasals) || [ ]).filter(function (b) {
+              if (!b || b.softDeleted || !b.pumpTimestamp || !b.guid) { return false; }
+              return !seen_guids.has(b.guid);
+            }),
+            glookoFoods: ((results[6] && results[6].foods) || [ ]).filter(function (f) {
+              if (!f || f.softDeleted || !f.timestamp || !f.guid) { return false; }
+              return !seen_guids.has(f.guid);
             })
             //settings: results[4].pumpSettings
          };

--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -46,6 +46,8 @@ var Defaults = {
 , LatestPumpBolus: '/api/v2/pumps/normal_boluses'
 , LatestCGMReadings: '/api/v2/cgm/readings'
 , PumpSettings: '/api/v2/external/pumps/settings'
+, PumpEvents: '/api/v2/pumps/events'
+, PumpAlarms: '/api/v2/pumps/alarms'
 , V3GraphData: '/api/v3/graph/data'
 , v3API: '/api/v3/graph/data?patient=_PATIENT_&startDate=_STARTDATE_&endDate=_ENDDATE_&series[]=automaticBolus&series[]=basalBarAutomated&series[]=basalBarAutomatedMax&series[]=basalBarAutomatedSuspend&series[]=basalLabels&series[]=basalModulation&series[]=bgAbove400&series[]=bgAbove400Manual&series[]=bgHigh&series[]=bgHighManual&series[]=bgLow&series[]=bgLowManual&series[]=bgNormal&series[]=bgNormalManual&series[]=bgTargets&series[]=carbNonManual&series[]=cgmCalibrationHigh&series[]=cgmCalibrationLow&series[]=cgmCalibrationNormal&series[]=cgmHigh&series[]=cgmLow&series[]=cgmNormal&series[]=deliveredBolus&series[]=deliveredBolus&series[]=extendedBolusStep&series[]=extendedBolusStep&series[]=gkCarb&series[]=gkInsulin&series[]=gkInsulin&series[]=gkInsulinBasal&series[]=gkInsulinBolus&series[]=gkInsulinOther&series[]=gkInsulinPremixed&series[]=injectionBolus&series[]=injectionBolus&series[]=interruptedBolus&series[]=interruptedBolus&series[]=lgsPlgs&series[]=overrideAboveBolus&series[]=overrideAboveBolus&series[]=overrideBelowBolus&series[]=overrideBelowBolus&series[]=pumpAdvisoryAlert&series[]=pumpAlarm&series[]=pumpBasaliqAutomaticMode&series[]=pumpBasaliqManualMode&series[]=pumpCamapsAutomaticMode&series[]=pumpCamapsBluetoothTurnedOffMode&series[]=pumpCamapsBoostMode&series[]=pumpCamapsDailyTotalInsulinExceededMode&series[]=pumpCamapsDepoweredMode&series[]=pumpCamapsEaseOffMode&series[]=pumpCamapsExtendedBolusNotAllowedMode&series[]=pumpCamapsManualMode&series[]=pumpCamapsNoCgmMode&series[]=pumpCamapsNoPumpConnectivityMode&series[]=pumpCamapsPumpDeliverySuspendedMode&series[]=pumpCamapsUnableToProceedMode&series[]=pumpControliqAutomaticMode&series[]=pumpControliqExerciseMode&series[]=pumpControliqManualMode&series[]=pumpControliqSleepMode&series[]=pumpGenericAutomaticMode&series[]=pumpGenericManualMode&series[]=pumpOp5AutomaticMode&series[]=pumpOp5HypoprotectMode&series[]=pumpOp5LimitedMode&series[]=pumpOp5ManualMode&series[]=reservoirChange&series[]=scheduledBasal&series[]=setSiteChange&series[]=suggestedBolus&series[]=suggestedBolus&series[]=suspendBasal&series[]=temporaryBasal&series[]=unusedScheduledBasal&locale=en-GB'
 // ?sessionID=e59c836f-5aeb-4b95-afa2-39cf2769fede&minutes=1440&maxCount=1"
@@ -140,7 +142,12 @@ function web_login_payload (opts, authenticityToken) {
     commit: 'Log in'
   });
 }
-function timestampWithOffset (timestamp, timestampDelta) {
+function timestampWithOffset (timestamp, timestampDelta, timezone) {
+  var mtz = null;
+  try { mtz = require('moment-timezone'); } catch (e) { mtz = null; }
+  if (timezone && mtz && mtz.tz.zone(timezone)) {
+    return mtz.tz(String(timestamp).replace(/Z$/, ''), timezone).toDate( );
+  }
   return new Date(new Date(timestamp).getTime( ) + (timestampDelta || 0));
 }
 function readingValueInMgdl (reading) {
@@ -151,7 +158,7 @@ function readingValueInMgdl (reading) {
   // Glooko v2 CGM values are commonly encoded as mg/dL x 100.
   return value > 1000 ? Math.round(value / 100) : value;
 }
-function readingToEntry (timestampDelta, reading) {
+function readingToEntry (timestampDelta, timezone, reading) {
   if (!reading || reading.softDeleted) {
     return null;
   }
@@ -160,7 +167,7 @@ function readingToEntry (timestampDelta, reading) {
   if (!timestamp || !sgv) {
     return null;
   }
-  var date = timestampWithOffset(timestamp, timestampDelta);
+  var date = timestampWithOffset(timestamp, timestampDelta, timezone);
   return {
     type: 'sgv',
     device: 'nightscout-connect-glooko',
@@ -170,11 +177,11 @@ function readingToEntry (timestampDelta, reading) {
     direction: 'Flat'
   };
 }
-function generate_nightscout_entries (readings, timestampDelta) {
+function generate_nightscout_entries (readings, timestampDelta, timezone) {
   if (!Array.isArray(readings)) {
     return [ ];
   }
-  return readings.map(readingToEntry.bind(null, timestampDelta)).filter(Boolean);
+  return readings.map(readingToEntry.bind(null, timestampDelta, timezone)).filter(Boolean);
 }
 function meterUnitsFromProfile (profile) {
   var user = profile && (profile.currentUser || profile.currentPatient || profile.user || profile.patient);
@@ -303,7 +310,7 @@ function glookoSource (opts, axios) {
     },
     dataFromSesssion (session, last_known) {
       var two_days_ago = new Date( ).getTime( ) - (2 * 24 * 60 * 60 * 1000);
-      var last_mills = Math.max(two_days_ago, (last_known && last_known.entries) ? last_known.entries.getTime( ) : two_days_ago);
+      var last_mills = Math.max(two_days_ago, (last_known && last_known.treatments) ? last_known.treatments.getTime( ) : two_days_ago);
       var last_glucose_at = new Date(last_mills);
       var maxCount = Math.ceil(((new Date( )).getTime( ) - last_mills) / (1000 * 60 * 5));
       var minutes = 5 * maxCount;
@@ -344,6 +351,7 @@ function glookoSource (opts, axios) {
         const myDate = new Date();
         const startDate = new Date(two_days_ago); // myDate.getTime() - 6 * 60 * 60 * 1000);
         const patientCode = getGlookoCode(session);
+        console.log('GLOOKO patientCode:', patientCode || 'MISSING', 'sessionUserKeys:', session && session.user ? Object.keys(session.user) : null);
         if (!patientCode) {
           return null;
         }
@@ -353,6 +361,34 @@ function glookoSource (opts, axios) {
          + "&endDate=" + myDate.toISOString();
 
         return url;
+      }
+
+      // Pod/site events are sparse - one burst every ~3 days - so they need a
+      // wider window than the 5-minute CGM cursor gives. Shares nothing with
+      // `params` on purpose.
+      function eventsFetcher (endpoint) {
+        var headers = { ...default_headers };
+        headers["Cookie"] = session.cookies;
+        headers["Host"] = baseHost;
+        headers["Sec-Fetch-Dest"] = "empty";
+        headers["Sec-Fetch-Mode"] = "cors";
+        headers["Sec-Fetch-Site"] = "same-site";
+        var wideStart = new Date(new Date( ).getTime( ) - 14 * 24 * 60 * 60 * 1000);
+        var wideParams = { lastGuid: Defaults.lastGuid,
+                           lastUpdatedAt: wideStart.toISOString( ),
+                           limit: 1000 };
+        var pc = getGlookoCode(session);
+        if (!pc) { return Promise.resolve({ events: [ ] }); }
+        var u = endpoint + '?patient=' + pc
+              + '&startDate=' + wideStart.toISOString( )
+              + '&endDate=' + new Date( ).toISOString( );
+        return http.get(u, { headers, params: wideParams })
+          .then((resp) => resp.data)
+          .catch(function (e) {
+            console.log('GLOOKO wide fetch failed', endpoint,
+                        e && e.response ? e.response.status : e && e.message);
+            return { events: [ ], alarms: [ ] };
+          });
       }
 
       const pumpBasalsUrl = constructUrl(Defaults.LatestPumpBasals);
@@ -366,12 +402,16 @@ function glookoSource (opts, axios) {
             fetcher(pumpBasalsUrl),
             fetcher(pumpBolusUrl),
             fetcher(cgmReadingsUrl),
+            eventsFetcher(Defaults.PumpEvents),
+            eventsFetcher(Defaults.PumpAlarms),
             //fetcher(constructUrl(Defaults.PumpSettings))
           ]
         : [
             Promise.resolve({ scheduledBasals: [] }),
             Promise.resolve({ normalBoluses: [] }),
-            Promise.resolve({ readings: [] })
+            Promise.resolve({ readings: [] }),
+            Promise.resolve({ events: [] }),
+            Promise.resolve({ alarms: [] })
           ];
 
       return Promise.all(v2Fetches).then(function (results) {
@@ -381,9 +421,27 @@ function glookoSource (opts, axios) {
             //insulins: results[1].insulins,
             scheduledBasals: results[0].scheduledBasals,
             normalBoluses: results[1].normalBoluses,
-            readings: results[2].readings
+            readings: results[2].readings,
+            pumpEvents: ((results[3] && results[3].events) || [ ]).filter(function (e) {
+              if (!e || e.softDeleted || !e.pumpTimestamp) { return false; }
+              var when = new Date(e.pumpTimestamp).getTime( ) + (opts.glookoTimezoneOffset || 0);
+              return when > last_mills;
+            }),
+            pumpAlarms: ((results[4] && results[4].alarms) || [ ]).filter(function (a) {
+              if (!a || a.soft_deleted || a.duplicate || !a.pump_timestamp) { return false; }
+              var when = new Date(a.pump_timestamp).getTime( ) + (opts.glookoTimezoneOffset || 0);
+              return when > last_mills;
+            })
             //settings: results[4].pumpSettings
          };
+         if (some.pumpAlarms && some.pumpAlarms.length) {
+           console.log('GLOOKO new alarms:',
+                       JSON.stringify(some.pumpAlarms.map(function (a) { return a.value; })));
+         }
+         if (some.pumpEvents && some.pumpEvents.length) {
+           console.log('GLOOKO new pump events:',
+                       JSON.stringify(some.pumpEvents.map(function (e) { return e.type; })));
+         }
 
          //console.log('food sample', JSON.stringify(some.food[0]));
          //console.log('insulins sample', JSON.stringify(some.insulins[0]));
@@ -429,8 +487,8 @@ function glookoSource (opts, axios) {
       // TODO
       console.log('GLOOKO passing batch for transforming');
       //console.log("TODO TRANSFORM", batch);
-      var treatments = helper.generate_nightscout_treatments(batch, opts.glookoTimezoneOffset);
-      var entries = generate_nightscout_entries(batch && batch.readings, opts.glookoTimezoneOffset);
+      var treatments = helper.generate_nightscout_treatments(batch, opts.glookoTimezoneOffset, opts.glookoTimezone);
+      var entries = generate_nightscout_entries(batch && batch.readings, opts.glookoTimezoneOffset, opts.glookoTimezone);
       if (!entries.length && opts.glookoUseV3Graph) {
         entries = generate_v3_nightscout_entries(batch && batch.v3Graph, opts.glookoTimezoneOffset, batch && batch.userProfile);
       }
@@ -487,7 +545,9 @@ glookoSource.validate = function validate_inputs (input) {
   var baseURL = base_for(input);
 
   const offset = !isNaN(input.glookoTimezoneOffset) ? input.glookoTimezoneOffset * -60 * 60 * 1000 : 0
-  console.log('GLOOKO using ms offset:', offset, input.glookoTimezoneOffset);
+  console.log('GLOOKO timestamps:', input.glookoTimezone
+    ? ('IANA zone ' + input.glookoTimezone + ' (DST-aware)')
+    : ('fixed offset ' + offset + 'ms - WILL BE AN HOUR WRONG ACROSS DST'));
 
   var config = {
     glookoEnv: input.glookoEnv,
@@ -495,6 +555,7 @@ glookoSource.validate = function validate_inputs (input) {
     glookoEmail: input.glookoEmail,
     glookoPassword: input.glookoPassword,
     glookoTimezoneOffset: offset,
+    glookoTimezone: input.glookoTimezone,
     glookoDeviceId: input.glookoDeviceId || makeUid(16),
     glookoSerialNumber: input.glookoSerialNumber || makeUid(24),
     glookoWebOrigin: web_origin_for(input),

--- a/test/glooko.test.js
+++ b/test/glooko.test.js
@@ -362,6 +362,15 @@ test('Glooko data fetch adds v3 graph fallback when v2 CGM readings are empty', 
     if (call.path.startsWith('/api/v2/cgm/readings')) {
       return Promise.resolve({ data: { readings: [] } });
     }
+    if (call.path.startsWith('/api/v2/pumps/events')) {
+      return Promise.resolve({ data: { events: [] } });
+    }
+    if (call.path.startsWith('/api/v2/pumps/alarms')) {
+      return Promise.resolve({ data: { alarms: [] } });
+    }
+    if (call.path.startsWith('/api/v2/foods')) {
+      return Promise.resolve({ data: { foods: [] } });
+    }
     if (call.path.startsWith('/api/v3/graph/data')) {
       assert.match(call.path, /series\[\]=cgmNormal/);
       assert.doesNotMatch(call.path, /series%5B%5D/);
@@ -376,7 +385,19 @@ test('Glooko data fetch adds v3 graph fallback when v2 CGM readings are empty', 
   }, { entries: new Date('2025-10-09T08:48:20.000Z') });
 
   assert.deepEqual(batch.v3Graph, { series: { cgmNormal: [{ x: 1760000000, value: 12345 }] } });
-  assert.equal(calls.length, 4);
+  // v2 basals + boluses + cgm readings, the pump events/alarms/foods this
+  // driver adds, and the v3 session + graph fallback
+  assert.deepEqual(calls.map((c) => c.path.split('?')[0]).sort(), [
+    '/api/v2/cgm/readings',
+    '/api/v2/foods',
+    '/api/v2/pumps/alarms',
+    '/api/v2/pumps/events',
+    '/api/v2/pumps/normal_boluses',
+    '/api/v2/pumps/normal_boluses',
+    '/api/v2/pumps/scheduled_basals',
+    '/api/v2/pumps/scheduled_basals',
+    '/api/v3/graph/data'
+  ]);
 });
 
 test('Glooko data fetch can resolve patient code from v3 session profile before graph fallback', async () => {


### PR DESCRIPTION
Addresses #45, which asks for Omnipod 5 basal and pump data that Glooko already
holds but the driver never requests.

Glooko has always carried the pump's own event log, alarm log, scheduled basals
and food entries. `/api/v2/pumps/events` and `/api/v2/pumps/alarms` were never
fetched at all, and `scheduled_basals` was fetched but always came back empty.
The result is that `cage`, `sage` and `iage` never populate for a pump that
records site and sensor changes itself, and somebody has to log them by hand in
careportal instead.

## What each commit does

**`d7c53c8` — pod, sensor and reservoir changes, and pump alarms**

```
pod_activating     -> Site Change      (CAGE)
cgm_sensor_change  -> Sensor Start     (SAGE)
reservoir_change   -> Insulin Change   (IAGE)
```

Alarms become `Note` treatments rather than `Announcement`, so they draw on the
graph without raising notifications. Glooko leaves `alarm_type` null — the
machine-readable code is in `value`.

These endpoints need their **own query window**. The shared `params` object pins
`lastUpdatedAt` near now and collapses `limit`, which against these endpoints
returns an empty array that looks exactly like "no data".

**`ddc5480` — deduplicate on guid rather than a timestamp**

Glooko's sync lag is around 40 minutes, so an event can arrive after a bolus
that happened later than it did. Against a timestamp cursor that event is
already behind the mark and is dropped permanently — a poor property for a pod
change or an alarm. Each treatment now carries `glookoGuid`; the output layer
seeds the known set from a 45-day window at startup and adds to it as it posts,
so a restart does not re-import the whole window.

**`5716508` — scheduled basals and logged food**

Food is imported as `Note`, deliberately **not** as carb treatments — the Meal
Bolus for the same meal already carries `carbsInput`, and a second carb entry
would double-count into COB.

**`0e918cb` — flag the gap between logged food and what was bolused for**

Food entries within 20 minutes are summed as one meal and matched to the nearest
bolus carrying `carbsInput`. A difference of 10 g or more emits a Note.

**`77f33e0` — review fixes** (see below)

## Things worth raising before you ask

**This overlaps #58.** Both add DST-correct Glooko timestamps via
`CONNECT_GLOOKO_TIMEZONE`; this branch does it with `moment-timezone` inside
`convert.js`. #58 is the more thorough treatment and I would rather rebase onto
it than duplicate it — happy to do that if you would like to take #58 first.

**`scheduled_basals` and `normal_boluses` are fetched twice per cycle.** Once
through `fetcher` with the narrow cursor, once through `eventsFetcher` with the
wide window that the food/bolus matching in `0e918cb` needs. That is deliberate
but it is a real extra round trip, and the test now asserts the full path list
so it is visible in the diff rather than buried. If `0e918cb` is dropped, the
second fetch of `normal_boluses` goes with it.

**`0e918cb` is the most opinionated commit here** and the easiest to drop. The
first three are mechanical — data Glooko holds, mapped onto event types
Nightscout already understands. The fourth makes a judgement about what is worth
surfacing and picks a 10 g threshold. If it is scope creep for this PR, say so
and I will pull it out; the other three stand on their own.

**`77f33e0` fixes three problems in the earlier commits**, found while preparing
this for review:

- the fake transport in `test/glooko.test.js` did not know about the endpoints
  this branch adds, so the fetch test failed on an unexpected path
- `seenGuids` was written to the bookmark even when empty, changing the persisted
  shape for every source and breaking two Nightscout output tests — it is now
  only carried when a source actually uses guids
- `commands/forever.js` merges the whole `argv` into `input` and then logged it.
  Under `yargs .env('CONNECT')` that includes `CONNECT_GLOOKO_PASSWORD` and
  `CONNECT_API_SECRET`. It now logs the shape, not the values. (Related to #61,
  which catches this class of leak more generally.)

## Tests

```
upstream main   47 tests, 47 pass
this branch     47 tests, 47 pass
```

Nightscout core is untouched. Enabling the resulting plugins is ordinary
Nightscout configuration and is out of scope here.
