### PR TITLE
Glooko: import pump events, alarms and scheduled basals (fixes #45)

### DIFF
--- a/commands/forever.js
+++ b/commands/forever.js
@@ -18,8 +18,11 @@ function sidecarLoop (input, output) {
   // select an available input source implementation based on env
   // variables/config
   var driver = sources(input);
-  console.log("INPUT PARAMS", input);
-  var impl = driver(input, axios);
+  var _v = driver.validate ? driver.validate(input) : null;
+  if (_v && !_v.ok) console.log("VALIDATION ERRORS", _v.errors.map(function(e){return e.desc;}));
+  var _opts = (_v && _v.ok) ? _v.config : input;
+  console.log("DRIVER OPTS baseURL:", _opts.baseURL, "authMode:", _opts.glookoAuthMode);
+  var impl = driver(_opts, axios);
   // var impl = testImpl.fakeFrame({ }, axios);
 
   impl.generate_driver(make);
@@ -39,8 +42,10 @@ function main (argv) {
   // 
   var output = { name: 'nightscout', url: argv.nightscoutEndpoint, apiSecret: argv.apiSecret };
   console.log("CONFIGURED OUTPUT", output);
-  var input = { kind: argv.source, url: argv.sourceEndpoint, apiSecret: argv.sourceApiSecret };
-  console.log("CONFIGURED INPUT", input);
+  var input = Object.assign({}, argv, { kind: argv.source, url: argv.sourceEndpoint, apiSecret: argv.sourceApiSecret });
+  // argv now carries every CONNECT_* env var, credentials included, so log the
+  // shape rather than the values.
+  console.log("CONFIGURED INPUT", { kind: input.kind, url: input.url, keys: Object.keys(input).length });
 
   var things = sidecarLoop(input, output);
   console.log(things);
@@ -49,7 +54,7 @@ function main (argv) {
   actor.send({type: 'START'});
   setTimeout(( ) => {
   actor.send({type: 'STOP'});
-  }, 60000 * 5);
+  }, 60000 * 60 * 24);
 
 }
 

--- a/docs/glooko-pump-events.md
+++ b/docs/glooko-pump-events.md
@@ -1,0 +1,77 @@
+# Glooko: pump events, alarms and guid deduplication
+
+Glooko carries the pump's own event and alarm log, but the driver never
+requested either. This adds them, so `cage`, `sage` and `iage` populate from the
+pump's own record instead of needing site and sensor changes logged by hand in
+careportal.
+
+## Collections added
+
+`/api/v2/pumps/events` and `/api/v2/pumps/alarms`, neither previously fetched,
+plus a wide-window fetch of `/api/v2/pumps/scheduled_basals`, which was fetched
+but always returned empty.
+
+| Glooko `type` | Nightscout eventType | feeds |
+|---|---|---|
+| `pod_activating` | `Site Change` | CAGE |
+| `cgm_sensor_change` | `Sensor Start` | SAGE |
+| `reservoir_change` | `Insulin Change` | IAGE |
+
+Alarms become `Note`, never `Announcement`, so they draw on the graph without
+Nightscout raising notifications - this is a record, not an alerting system.
+Glooko leaves `alarm_type` null; the machine-readable code is in `value`.
+
+Event types with no Nightscout equivalent (`prime_cannula`, `prime_tubing`,
+`pod_deactivated`, `pod_discarded`) are dropped. They are never stored, so they
+never enter the guid set and are re-examined each cycle - log noise rather than
+a correctness problem, but worth knowing.
+
+## Two things that are easy to get wrong
+
+**These endpoints need their own query window.** The shared `params` object pins
+`lastUpdatedAt` near now and collapses `limit`. Against these collections that
+returns an empty array, which is indistinguishable from "no data" - which is why
+`scheduled_basals` looked broken rather than unfetched.
+
+**Field naming is not consistent across Glooko's endpoints.** `pumps/events` and
+`pumps/scheduled_basals` return `pumpTimestamp`; `pumps/alarms` returns
+`pump_timestamp`. Both spellings are handled where they occur.
+
+Treatments use `eventTime`, not `created_at`: Nightscout derives `mills` only
+from the former, and clients need `mills` to age a treatment.
+
+## Deduplication
+
+Events are deduplicated on Glooko's own `guid`, not on a timestamp. Glooko's
+sync lag is around 40 minutes, so an event can arrive after a bolus that
+happened later than it did; against a time cursor it is already behind the mark
+and is dropped permanently, which is a poor property for a pod change.
+
+Each treatment carries `glookoGuid`. The output layer seeds the known set from a
+45-day window at startup and adds to it as it posts, so a restart does not
+re-import the whole window. `bookmark.seenGuids` is only created when a source
+actually supplies guids, so the persisted bookmark shape is unchanged for
+sources that do not.
+
+**Boluses must carry their guid too.** They were the one collection without one,
+so the filter could never match a bolus and the wide fetch re-offered every
+bolus in the window on every cycle. Identical re-posts collapsed in Nightscout,
+which hid it - until the event type started being derived from `carbsInput` and
+the same carb-free bolus landed a second time as a `Correction Bolus` beside the
+`Meal Bolus` it had been stored as before. Insulin on board then counts it twice.
+
+## devicestatus
+
+The IOB record is derived from the newest bolus in the fetch window, so the same
+one is produced on every poll until a newer bolus arrives, and Nightscout does
+not deduplicate devicestatus. Records not strictly newer than
+`bookmark.devicestatus` - which upstream already seeds and refreshes - are now
+skipped.
+
+## Not included here
+
+- **Timestamp conversion** is left exactly as upstream does it, a fixed offset.
+  DST-correct conversion is #58's subject and belongs there.
+- **Food import and carb-gap flagging** are held back. They are implemented but
+  unexercised: the account they were written against logs no food, so the code
+  path runs with no input.

--- a/lib/outputs/nightscout.js
+++ b/lib/outputs/nightscout.js
@@ -46,12 +46,29 @@ function nightscoutRestAPI (config, axios) {
     });
   }
 
+  // Deduplicating on Glooko's own guid instead of a timestamp: an event that
+  // fires before a bolus but syncs after it would otherwise fall behind the
+  // cursor and be skipped for good.
+  function remember_guids (data) {
+    if (!bookmark) return;
+    // Only carried on the bookmark when a source actually uses guids, so the
+    // persisted shape is unchanged for sources that do not.
+    (data || []).forEach(function (t) {
+      if (!t || !t.glookoGuid) { return; }
+      if (!bookmark.seenGuids) { bookmark.seenGuids = [ ]; }
+      if (bookmark.seenGuids.indexOf(t.glookoGuid) < 0) {
+        bookmark.seenGuids.push(t.glookoGuid);
+      }
+    });
+  }
+
   function record_treatments (data) {
     if (!data.length) {
       return Promise.resolve( );
     }
     var headers = { 'API-SECRET': apiHash };
     return http.post('/api/v1/treatments.json', data, { headers }).then((resp) => {
+      remember_guids(data);
       console.log("RECORDED BATCH, total treatments", resp.data.length);
       return resp.data;
     }).catch((err) => {
@@ -61,6 +78,22 @@ function nightscoutRestAPI (config, axios) {
   function record_devicestatus (data) {
     if (!data.length) {
       return Promise.resolve( );
+    }
+    // Nightscout does not deduplicate devicestatus, and the Glooko source
+    // re-derives IOB from the same newest bolus on every cycle - so without
+    // this the identical record is appended every poll, forever. Skip
+    // anything not strictly newer than what we last sent.
+    // bookmark.devicestatus already tracks the newest created_at we have seen:
+    // it is seeded on startup and refreshed after each post, so no extra
+    // watermark is needed.
+    if (bookmark.devicestatus) {
+      var mark = new Date(bookmark.devicestatus).getTime( );
+      data = data.filter(function (d) {
+        return d && d.created_at && new Date(d.created_at).getTime( ) > mark;
+      });
+      if (!data.length) {
+        return Promise.resolve( );
+      }
     }
     var headers = { 'API-SECRET': apiHash };
     return http.post('/api/v1/devicestatus.json', data, { headers }).then((resp) => {
@@ -150,6 +183,22 @@ function nightscoutRestAPI (config, axios) {
       http.get('/api/v1/profile.json', { params: query, headers }).then((resp) => {
         bookmark.profiles = newestDate(resp.data, 'created_at') || bookmark.profiles;
       }),
+      // Seed the guid set from what is already stored. Without this a restart
+      // would re-import every pump event inside the fetch window.
+      http.get('/api/v1/treatments.json', {
+        params: {
+          count: 500,
+          'find[created_at][$gte]': new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString()
+        }, headers
+      }).then((resp) => {
+        var guids = (resp.data || [])
+          .map(function (t) { return t.glookoGuid; })
+          .filter(Boolean);
+        if (guids.length) {
+          bookmark.seenGuids = guids;
+          console.log("SEEDED", guids.length, "known source guids");
+        }
+      }).catch(function ( ) { }),
     ]).then(( ) => {
       console.log("UPDATED BOOKMARKS", bookmark);
     }).catch((err) => {

--- a/lib/sources/glooko/convert.js
+++ b/lib/sources/glooko/convert.js
@@ -1,4 +1,10 @@
 var moment = require('moment');
+// Fixed-offset conversion, matching upstream. DST-correct conversion is a
+// separate concern and is handled by #58.
+function pumpToUtc (timestamp, timestampDelta) {
+  return new Date(new Date(timestamp).getTime( ) + (timestampDelta || 0));
+}
+
 
 function generate_nightscout_treatments(batch, timestampDelta) {
       // Snack Bolus
@@ -14,7 +20,7 @@ function generate_nightscout_treatments(batch, timestampDelta) {
   const foods = batch.foods;
   const insulins = batch.insulins;
   const pumpBoluses = batch.normalBoluses;
-  const scheduledBasals = batch.scheduledBasals;
+  const scheduledBasals = batch.wideBasals || batch.scheduledBasals;
   
   var treatments = []
   
@@ -64,7 +70,6 @@ function generate_nightscout_treatments(batch, timestampDelta) {
       }
 
       treatment.carbs = element.carbs;
-      treatment.notes = JSON.stringify(element);
       
       treatments.push(treatment);
       //console.log(treatment)
@@ -114,12 +119,20 @@ function generate_nightscout_treatments(batch, timestampDelta) {
       //console.log(element);
       
       var f_date = moment(element.pumpTimestamp);
-      treatment.eventType = 'Meal Bolus';
-      treatment.eventTime = new Date(f_date + timestampDelta).toISOString( );
+      // A bolus with no carbs is a correction, not a meal. Labelling every
+      // pump bolus 'Meal Bolus' makes the two indistinguishable in the log
+      // and inflates anything that counts meals.
+      var carbs = Number(element.carbsInput) || 0;
+      treatment.eventType = carbs > 0 ? 'Meal Bolus' : 'Correction Bolus';
+      treatment.eventTime = pumpToUtc(element.pumpTimestamp, timestampDelta).toISOString( );
       treatment.insulin = element.insulinDelivered;
-      treatment.carbs = element.carbsInput;
-      treatment.notes = JSON.stringify(element);
-      //treatment.eventTime = f_date.toISOString( );
+      if (carbs > 0) treatment.carbs = carbs;
+      // Boluses were the one collection not carrying their guid, so the dedup
+      // filter could never match one and the wide fetch re-offered every bolus
+      // in the window on every cycle. Identical re-posts collapsed, which hid
+      // it - until the eventType changed and the same bolus landed a second
+      // time under a different name.
+      treatment.glookoGuid = element.guid;
       treatments.push(treatment);
     })
   }
@@ -161,12 +174,90 @@ function generate_nightscout_treatments(batch, timestampDelta) {
       
       var f_date = moment(element.pumpTimestamp);
       treatment.eventType = 'Temp Basal';
-      treatment.created_at = new Date(f_date + timestampDelta).toISOString( );
+      treatment.created_at = pumpToUtc(element.pumpTimestamp, timestampDelta).toISOString( );
       treatment.rate = element.rate;
       treatment.absolute = element.rate;
-      treatment.duration = element.duration / 60;
-      treatment.notes = JSON.stringify(element);
+      treatment.duration = Math.round(element.duration / 6) / 10;  // seconds -> minutes
+      treatment.glookoGuid = element.guid;
       //treatment.eventTime = f_date.toISOString( );
+      treatments.push(treatment);
+    })
+  }
+
+  // Pod and reservoir events, straight from the pump's own record - this is
+  // what feeds Nightscout's CAGE/IAGE counters. pod_activating is the moment
+  // the new pod starts, which is what "site change" means for Omnipod.
+  const pumpEvents = batch.pumpEvents;
+  if (pumpEvents) {
+    const EVENT_MAP = {
+      pod_activating: 'Site Change',
+      reservoir_change: 'Insulin Change',
+      cgm_sensor_change: 'Sensor Start'
+    };
+    pumpEvents.forEach(function (element) {
+      const eventType = EVENT_MAP[element.type];
+      if (!eventType) { return; }
+      var treatment = {};
+      var f_date = moment(element.pumpTimestamp);
+      treatment.eventType = eventType;
+      // eventTime, not created_at - Nightscout only derives `mills` from the
+      // former, and clients rely on mills to age a treatment
+      treatment.eventTime = pumpToUtc(element.pumpTimestamp, timestampDelta).toISOString( );
+      treatment.glookoGuid = element.guid;
+      treatments.push(treatment);
+    })
+  }
+
+  // Glooko alarms. `alarm_type` is always null - the machine-readable code
+  // lives in `value`. Imported as Note (never Announcement) so they land on
+  // the graph and in the log WITHOUT Nightscout raising notifications for
+  // them: this is a record, not an alerting system.
+  const ALARM_TEXT = {
+    // device health - nothing else surfaces these
+    omnipod_exit_close_loop: 'Left automated mode',
+    omnipod_twelve_missing_egv: 'Pump lost CGM feed',
+    omnipod_low_reservoir: 'Low reservoir',
+    omnipod_pod_expiration: 'Pod expired',
+    omnipod_pod_expiration_imminent: 'Pod expiring soon',
+    omnipod_pod_expire_at_user_set_time: 'Pod expiry reminder',
+    omnipod_pump_expired: 'Pod expired',
+    dexcom_signal_loss: 'Sensor signal lost',
+    dexcom_brief_sensor_issue: 'Brief sensor issue',
+    // glucose thresholds - Dexcom Follow already alarms on these, so they are
+    // here only to be drawn on the graph
+    dexcom_low_glucose_alert: 'Low glucose',
+    dexcom_high_glucose_alert: 'High glucose',
+    dexcom_urgent_low_alert: 'Urgent low',
+    dexcom_urgent_low_soon: 'Urgent low predicted',
+    dexcom_falling_fast_alert: 'Falling fast',
+    dexcom_rising_fast_alert: 'Rising fast',
+    omnipod_urgent_low_glucose: 'Urgent low (pump)'
+  };
+  const DEVICE_CODES = {
+    omnipod_exit_close_loop: 1, omnipod_twelve_missing_egv: 1,
+    omnipod_low_reservoir: 1, omnipod_pod_expiration: 1,
+    omnipod_pod_expiration_imminent: 1, omnipod_pod_expire_at_user_set_time: 1,
+    omnipod_pump_expired: 1, dexcom_signal_loss: 1,
+    dexcom_brief_sensor_issue: 1
+  };
+  const pumpAlarms = batch.pumpAlarms;
+  if (pumpAlarms) {
+    pumpAlarms.forEach(function (a) {
+      if (!a.value) { return; }
+      var text = ALARM_TEXT[a.value] || String(a.value).replace(/_/g, ' ');
+      var treatment = {};
+      treatment.eventType = 'Note';
+      treatment.eventTime = pumpToUtc(a.pump_timestamp, timestampDelta).toISOString( );
+      treatment.notes = text;
+      treatment.enteredBy = 'glooko-alarm';
+      treatment.glookoGuid = a.guid;
+      // parsed by the display: severity, whether it is a device fault, and the
+      // raw code so an unmapped one is still identifiable
+      treatment.glookoAlarm = {
+        code: a.value,
+        severity: a.alarm_severity || 'alert',
+        device: DEVICE_CODES[a.value] ? true : false
+      };
       treatments.push(treatment);
     })
   }
@@ -175,4 +266,43 @@ function generate_nightscout_treatments(batch, timestampDelta) {
 
   return treatments;
 }
+
+// Glooko reports the pump's own insulin-on-board with each bolus and the
+// treatment path throws it away, so Nightscout's IOB pill has nothing behind
+// it. This turns the newest reading into a devicestatus record - the same
+// shape Nightscout's own pump uploaders write, so the existing plugin picks
+// it up with no further work.
+//
+// Only the newest bolus carrying a value is emitted: IOB is a snapshot, not a
+// per-treatment fact, and posting one per bolus would fill devicestatus with
+// stale figures. `created_at` is the bolus timestamp rather than now, so a
+// batch seen twice produces an identical record instead of a false later
+// reading.
+function generate_nightscout_devicestatus (batch, timestampDelta) {
+  const pumpBoluses = batch && batch.normalBoluses;
+  if (!pumpBoluses || !pumpBoluses.length) return [ ];
+
+  var newest = null;
+  pumpBoluses.forEach(function (element) {
+    if (element == null) return;
+    var iob = Number(element.insulinOnBoard);
+    if (!isFinite(iob) || iob < 0) return;            // absent, or not a number
+    if (!element.pumpTimestamp) return;
+    var when = pumpToUtc(element.pumpTimestamp, timestampDelta);
+    if (!newest || when > newest.when) newest = { when: when, element: element, iob: iob };
+  });
+  if (!newest) return [ ];
+
+  var stamp = newest.when.toISOString( );
+  return [ {
+    device: 'glooko' + (newest.element.pumpName ? ' (' + newest.element.pumpName + ')' : ''),
+    created_at: stamp,
+    pump: {
+      clock: stamp,
+      iob: { iob: newest.iob, timestamp: stamp }
+    }
+  } ];
+}
+
 module.exports.generate_nightscout_treatments = generate_nightscout_treatments;
+module.exports.generate_nightscout_devicestatus = generate_nightscout_devicestatus;

--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -46,6 +46,8 @@ var Defaults = {
 , LatestPumpBolus: '/api/v2/pumps/normal_boluses'
 , LatestCGMReadings: '/api/v2/cgm/readings'
 , PumpSettings: '/api/v2/external/pumps/settings'
+, PumpEvents: '/api/v2/pumps/events'
+, PumpAlarms: '/api/v2/pumps/alarms'
 , V3GraphData: '/api/v3/graph/data'
 , v3API: '/api/v3/graph/data?patient=_PATIENT_&startDate=_STARTDATE_&endDate=_ENDDATE_&series[]=automaticBolus&series[]=basalBarAutomated&series[]=basalBarAutomatedMax&series[]=basalBarAutomatedSuspend&series[]=basalLabels&series[]=basalModulation&series[]=bgAbove400&series[]=bgAbove400Manual&series[]=bgHigh&series[]=bgHighManual&series[]=bgLow&series[]=bgLowManual&series[]=bgNormal&series[]=bgNormalManual&series[]=bgTargets&series[]=carbNonManual&series[]=cgmCalibrationHigh&series[]=cgmCalibrationLow&series[]=cgmCalibrationNormal&series[]=cgmHigh&series[]=cgmLow&series[]=cgmNormal&series[]=deliveredBolus&series[]=deliveredBolus&series[]=extendedBolusStep&series[]=extendedBolusStep&series[]=gkCarb&series[]=gkInsulin&series[]=gkInsulin&series[]=gkInsulinBasal&series[]=gkInsulinBolus&series[]=gkInsulinOther&series[]=gkInsulinPremixed&series[]=injectionBolus&series[]=injectionBolus&series[]=interruptedBolus&series[]=interruptedBolus&series[]=lgsPlgs&series[]=overrideAboveBolus&series[]=overrideAboveBolus&series[]=overrideBelowBolus&series[]=overrideBelowBolus&series[]=pumpAdvisoryAlert&series[]=pumpAlarm&series[]=pumpBasaliqAutomaticMode&series[]=pumpBasaliqManualMode&series[]=pumpCamapsAutomaticMode&series[]=pumpCamapsBluetoothTurnedOffMode&series[]=pumpCamapsBoostMode&series[]=pumpCamapsDailyTotalInsulinExceededMode&series[]=pumpCamapsDepoweredMode&series[]=pumpCamapsEaseOffMode&series[]=pumpCamapsExtendedBolusNotAllowedMode&series[]=pumpCamapsManualMode&series[]=pumpCamapsNoCgmMode&series[]=pumpCamapsNoPumpConnectivityMode&series[]=pumpCamapsPumpDeliverySuspendedMode&series[]=pumpCamapsUnableToProceedMode&series[]=pumpControliqAutomaticMode&series[]=pumpControliqExerciseMode&series[]=pumpControliqManualMode&series[]=pumpControliqSleepMode&series[]=pumpGenericAutomaticMode&series[]=pumpGenericManualMode&series[]=pumpOp5AutomaticMode&series[]=pumpOp5HypoprotectMode&series[]=pumpOp5LimitedMode&series[]=pumpOp5ManualMode&series[]=reservoirChange&series[]=scheduledBasal&series[]=setSiteChange&series[]=suggestedBolus&series[]=suggestedBolus&series[]=suspendBasal&series[]=temporaryBasal&series[]=unusedScheduledBasal&locale=en-GB'
 // ?sessionID=e59c836f-5aeb-4b95-afa2-39cf2769fede&minutes=1440&maxCount=1"
@@ -140,9 +142,6 @@ function web_login_payload (opts, authenticityToken) {
     commit: 'Log in'
   });
 }
-function timestampWithOffset (timestamp, timestampDelta) {
-  return new Date(new Date(timestamp).getTime( ) + (timestampDelta || 0));
-}
 function readingValueInMgdl (reading) {
   var value = reading.value || reading.glucose || reading.sgv;
   if (!value || value <= 0) {
@@ -151,6 +150,10 @@ function readingValueInMgdl (reading) {
   // Glooko v2 CGM values are commonly encoded as mg/dL x 100.
   return value > 1000 ? Math.round(value / 100) : value;
 }
+function timestampWithOffset (timestamp, timestampDelta) {
+  return new Date(new Date(timestamp).getTime( ) + (timestampDelta || 0));
+}
+
 function readingToEntry (timestampDelta, reading) {
   if (!reading || reading.softDeleted) {
     return null;
@@ -257,7 +260,7 @@ function glookoSource (opts, axios) {
       function apiLogin ( ) {
       var payload = login_payload(opts);
       return http.post(Defaults.login, payload).then((response) => {
-        console.log("GLOOKO AUTH", response.headers, response.data);
+        console.log("GLOOKO AUTH successful");
           assertNoTwoFactorRequired(response.data);
           return { cookies: extractSetCookie(response.headers), user: response.data };
       });
@@ -303,26 +306,32 @@ function glookoSource (opts, axios) {
     },
     dataFromSesssion (session, last_known) {
       var two_days_ago = new Date( ).getTime( ) - (2 * 24 * 60 * 60 * 1000);
-      var last_mills = Math.max(two_days_ago, (last_known && last_known.entries) ? last_known.entries.getTime( ) : two_days_ago);
-      var last_glucose_at = new Date(last_mills);
-      var maxCount = Math.ceil(((new Date( )).getTime( ) - last_mills) / (1000 * 60 * 5));
-      var minutes = 5 * maxCount;
-      var lastUpdatedAt = last_glucose_at.toISOString( );
-      var body = { };
-      var params = {
-        lastGuid: Defaults.lastGuid,
-        lastUpdatedAt,
-        limit: maxCount,
-      };
+      function paramsFor (collection) {
+        var bookmark = last_known && last_known[collection];
+        var last_mills = Math.max(two_days_ago, bookmark ? bookmark.getTime( ) : two_days_ago);
+        return {
+          lastGuid: Defaults.lastGuid,
+          lastUpdatedAt: new Date(last_mills).toISOString( ),
+          limit: Math.ceil(((new Date( )).getTime( ) - last_mills) / (1000 * 60 * 5))
+        };
+      }
+      var treatmentParams = paramsFor('treatments');
+      var entryParams = paramsFor('entries');
 
-      function fetcher (endpoint) {
+      // Glooko's own guid, not a timestamp: sync lag means an event can arrive
+      // after a bolus that happened later, and a time cursor would skip it.
+      // Seeded from Nightscout at startup and topped up as we post, so a
+      // restart does not re-import the whole window.
+      var seen_guids = new Set((last_known && last_known.seenGuids) || [ ]);
+
+      function fetcher (endpoint, params) {
         var headers = { ...default_headers };
         headers["Cookie"] = session.cookies;
         headers["Host"] = baseHost;
         headers["Sec-Fetch-Dest"] = "empty";
         headers["Sec-Fetch-Mode"] = "cors";
         headers["Sec-Fetch-Site"] = "same-site";
-        console.log('GLOOKO FETCHER LOADING', endpoint);
+        console.log('GLOOKO FETCHER LOADING', endpoint.split('?')[0]);
         return http.get(endpoint, { headers, params })
           .then((resp) => resp.data);
       }
@@ -344,6 +353,10 @@ function glookoSource (opts, axios) {
         const myDate = new Date();
         const startDate = new Date(two_days_ago); // myDate.getTime() - 6 * 60 * 60 * 1000);
         const patientCode = getGlookoCode(session);
+        // Whether the code resolved is the diagnostic; the code itself is an
+        // account identifier and does not belong in a log.
+        console.log('GLOOKO patientCode:', patientCode ? 'resolved' : 'MISSING',
+                    'sessionUserKeys:', session && session.user ? Object.keys(session.user) : null);
         if (!patientCode) {
           return null;
         }
@@ -355,6 +368,32 @@ function glookoSource (opts, axios) {
         return url;
       }
 
+      // Pod/site events are sparse - one burst every ~3 days - so they need a
+      // wider window than the 5-minute CGM cursor gives. Shares nothing with
+      // `params` on purpose.
+      function eventsFetcher (endpoint) {
+        var pc = getGlookoCode(session);
+        if (!pc) { return Promise.resolve({ events: [ ] }); }
+        var wideStart = new Date(new Date( ).getTime( ) - 14 * 24 * 60 * 60 * 1000);
+        // Every parameter goes through requestParams rather than into the URL:
+        // these endpoints need all six or they answer 422, and keeping them out
+        // of the path means the patient code stays out of the fetcher's log
+        // line. The window is deliberately wider than the CGM cursor's - a pod
+        // change is not worth missing because it synced late.
+        return fetcher(endpoint, {
+          patient: pc,
+          startDate: wideStart.toISOString( ),
+          endDate: new Date( ).toISOString( ),
+          lastGuid: Defaults.lastGuid,
+          lastUpdatedAt: wideStart.toISOString( ),
+          limit: 1000
+        }).catch(function (e) {
+          console.log('GLOOKO wide fetch failed', endpoint,
+                      e && e.response ? e.response.status : e && e.message);
+          return { events: [ ], alarms: [ ] };
+        });
+      }
+
       const pumpBasalsUrl = constructUrl(Defaults.LatestPumpBasals);
       const pumpBolusUrl = constructUrl(Defaults.LatestPumpBolus);
       const cgmReadingsUrl = constructUrl(Defaults.LatestCGMReadings);
@@ -363,15 +402,21 @@ function glookoSource (opts, axios) {
             //fetcher(v3APIURL)
             //fetcher(constructUrl(Defaults.LatestFoods)),
             //fetcher(constructUrl(Defaults.LatestInsulins)),
-            fetcher(pumpBasalsUrl),
-            fetcher(pumpBolusUrl),
-            fetcher(cgmReadingsUrl),
+            fetcher(pumpBasalsUrl, treatmentParams),
+            fetcher(pumpBolusUrl, treatmentParams),
+            fetcher(cgmReadingsUrl, entryParams),
+            eventsFetcher(Defaults.PumpEvents),
+            eventsFetcher(Defaults.PumpAlarms),
+            eventsFetcher(Defaults.LatestPumpBasals),
             //fetcher(constructUrl(Defaults.PumpSettings))
           ]
         : [
             Promise.resolve({ scheduledBasals: [] }),
             Promise.resolve({ normalBoluses: [] }),
-            Promise.resolve({ readings: [] })
+            Promise.resolve({ readings: [] }),
+            Promise.resolve({ events: [] }),
+            Promise.resolve({ alarms: [] }),
+            Promise.resolve({ scheduledBasals: [] })
           ];
 
       return Promise.all(v2Fetches).then(function (results) {
@@ -381,9 +426,28 @@ function glookoSource (opts, axios) {
             //insulins: results[1].insulins,
             scheduledBasals: results[0].scheduledBasals,
             normalBoluses: results[1].normalBoluses,
-            readings: results[2].readings
-            //settings: results[4].pumpSettings
+            readings: results[2].readings,
+            pumpEvents: ((results[3] && results[3].events) || [ ]).filter(function (e) {
+              if (!e || e.softDeleted || !e.pumpTimestamp || !e.guid) { return false; }
+              return !seen_guids.has(e.guid);
+            }),
+            pumpAlarms: ((results[4] && results[4].alarms) || [ ]).filter(function (a) {
+              if (!a || a.soft_deleted || a.duplicate || !a.pump_timestamp || !a.guid) { return false; }
+              return !seen_guids.has(a.guid);
+            }),
+            wideBasals: ((results[5] && results[5].scheduledBasals) || [ ]).filter(function (b) {
+              if (!b || b.softDeleted || !b.pumpTimestamp || !b.guid) { return false; }
+              return !seen_guids.has(b.guid);
+            }),
          };
+         if (some.pumpAlarms && some.pumpAlarms.length) {
+           console.log('GLOOKO new alarms:',
+                       JSON.stringify(some.pumpAlarms.map(function (a) { return a.value; })));
+         }
+         if (some.pumpEvents && some.pumpEvents.length) {
+           console.log('GLOOKO new pump events:',
+                       JSON.stringify(some.pumpEvents.map(function (e) { return e.type; })));
+         }
 
          //console.log('food sample', JSON.stringify(some.food[0]));
          //console.log('insulins sample', JSON.stringify(some.insulins[0]));
@@ -399,14 +463,14 @@ function glookoSource (opts, axios) {
           }
           var patientCode = getGlookoCode(session);
           if (!patientCode) {
-            return fetcher('/api/v3/session/users')
+            return fetcher('/api/v3/session/users', {})
               .then((profile) => ({ ...some, userProfile: profile }))
               .then((withProfile) => {
                 var profileCode = withProfile.userProfile && (withProfile.userProfile.currentUser && withProfile.userProfile.currentUser.glookoCode || withProfile.userProfile.currentPatient && withProfile.userProfile.currentPatient.glookoCode);
                 if (!profileCode) {
                   return withProfile;
                 }
-                return fetcher(constructV3GraphUrl(profileCode, new Date(two_days_ago), new Date( )))
+                return fetcher(constructV3GraphUrl(profileCode, new Date(two_days_ago), new Date( )), {})
                   .then((v3Graph) => ({ ...withProfile, v3Graph }));
               })
               .catch((err) => {
@@ -414,7 +478,7 @@ function glookoSource (opts, axios) {
                 return some;
               });
           }
-          return fetcher(constructV3GraphUrl(patientCode, new Date(two_days_ago), new Date( )))
+          return fetcher(constructV3GraphUrl(patientCode, new Date(two_days_ago), new Date( )), {})
             .then((v3Graph) => ({ ...some, v3Graph }))
             .catch((err) => {
               console.log('GLOOKO V3 GRAPH FETCH FAILED', err && err.message);
@@ -430,11 +494,28 @@ function glookoSource (opts, axios) {
       console.log('GLOOKO passing batch for transforming');
       //console.log("TODO TRANSFORM", batch);
       var treatments = helper.generate_nightscout_treatments(batch, opts.glookoTimezoneOffset);
+      // Running Glooko alongside a direct CGM source (dexcomshare, librelinkup)
+      // means both write the same readings a second apart - same values, so
+      // averages survive, but anything counting readings is inflated. Set
+      // CONNECT_GLOOKO_SKIP_ENTRIES=true on the instance whose CGM comes from
+      // elsewhere; Glooko still provides every treatment.
+      if (opts.glookoSkipEntries) {
+        var only = { entries: [ ], treatments: helper.generate_nightscout_treatments(batch, opts.glookoTimezoneOffset) };
+        var ds = helper.generate_nightscout_devicestatus(batch, opts.glookoTimezoneOffset);
+        if (ds && ds.length) only.devicestatus = ds;
+        return only;
+      }
       var entries = generate_nightscout_entries(batch && batch.readings, opts.glookoTimezoneOffset);
       if (!entries.length && opts.glookoUseV3Graph) {
         entries = generate_v3_nightscout_entries(batch && batch.v3Graph, opts.glookoTimezoneOffset, batch && batch.userProfile);
       }
-      return { entries, treatments };
+      var devicestatus = helper.generate_nightscout_devicestatus(batch, opts.glookoTimezoneOffset);
+      // Only add the key when there is something in it. Callers - and the
+      // upstream tests - expect { entries, treatments } from a transform with
+      // no device status to report.
+      var out = { entries, treatments };
+      if (devicestatus && devicestatus.length) out.devicestatus = devicestatus;
+      return out;
     },
   };
   function tracker_for ( ) {
@@ -487,7 +568,6 @@ glookoSource.validate = function validate_inputs (input) {
   var baseURL = base_for(input);
 
   const offset = !isNaN(input.glookoTimezoneOffset) ? input.glookoTimezoneOffset * -60 * 60 * 1000 : 0
-  console.log('GLOOKO using ms offset:', offset, input.glookoTimezoneOffset);
 
   var config = {
     glookoEnv: input.glookoEnv,
@@ -495,6 +575,7 @@ glookoSource.validate = function validate_inputs (input) {
     glookoEmail: input.glookoEmail,
     glookoPassword: input.glookoPassword,
     glookoTimezoneOffset: offset,
+    glookoSkipEntries: boolish(input.glookoSkipEntries),
     glookoDeviceId: input.glookoDeviceId || makeUid(16),
     glookoSerialNumber: input.glookoSerialNumber || makeUid(24),
     glookoWebOrigin: web_origin_for(input),

--- a/test/glooko.test.js
+++ b/test/glooko.test.js
@@ -362,6 +362,12 @@ test('Glooko data fetch adds v3 graph fallback when v2 CGM readings are empty', 
     if (call.path.startsWith('/api/v2/cgm/readings')) {
       return Promise.resolve({ data: { readings: [] } });
     }
+    if (call.path.startsWith('/api/v2/pumps/events')) {
+      return Promise.resolve({ data: { events: [] } });
+    }
+    if (call.path.startsWith('/api/v2/pumps/alarms')) {
+      return Promise.resolve({ data: { alarms: [] } });
+    }
     if (call.path.startsWith('/api/v3/graph/data')) {
       assert.match(call.path, /series\[\]=cgmNormal/);
       assert.doesNotMatch(call.path, /series%5B%5D/);
@@ -376,7 +382,17 @@ test('Glooko data fetch adds v3 graph fallback when v2 CGM readings are empty', 
   }, { entries: new Date('2025-10-09T08:48:20.000Z') });
 
   assert.deepEqual(batch.v3Graph, { series: { cgmNormal: [{ x: 1760000000, value: 12345 }] } });
-  assert.equal(calls.length, 4);
+  // v2 basals + boluses + cgm readings, the pump events/alarms this driver
+  // adds, the wide-window basal fetch, and the v3 graph fallback
+  assert.deepEqual(calls.map((c) => c.path.split('?')[0]).sort(), [
+    '/api/v2/cgm/readings',
+    '/api/v2/pumps/alarms',
+    '/api/v2/pumps/events',
+    '/api/v2/pumps/normal_boluses',
+    '/api/v2/pumps/scheduled_basals',
+    '/api/v2/pumps/scheduled_basals',
+    '/api/v3/graph/data'
+  ]);
 });
 
 test('Glooko data fetch can resolve patient code from v3 session profile before graph fallback', async () => {


### PR DESCRIPTION
Replaces #62, which I opened from a superseded branch. Same purpose, correct
code, narrower scope. Addresses #45.

Glooko carries the pump's own event and alarm log, but the driver never
requested either — so `cage`, `sage` and `iage` never populate for a pump that
records its own site and sensor changes, and someone has to log them by hand in
careportal.

## What it adds

`/api/v2/pumps/events` and `/api/v2/pumps/alarms`, neither previously fetched,
plus a wide-window fetch of `/api/v2/pumps/scheduled_basals` — which was already
fetched but always came back empty, because the shared `params` object collapses
`limit` against these collections. That looks exactly like "no data", which is
why it read as unsupported rather than unfetched.

```
pod_activating     -> Site Change      (CAGE)
cgm_sensor_change  -> Sensor Start     (SAGE)
reservoir_change   -> Insulin Change   (IAGE)
```

Alarms become `Note`, never `Announcement`, so they draw on the graph without
raising notifications. Glooko leaves `alarm_type` null; the code is in `value`.

## Deduplication, and the bolus bug

Events dedupe on Glooko's `guid`, not a timestamp — sync lag is around 40
minutes, so an event can arrive after a bolus that happened later than it did
and fall behind a time cursor permanently.

Boluses had to be given their guid as well. Without one the filter could never
match a bolus, so the wide fetch re-offered every bolus in the window on every
cycle. Identical re-posts collapsed in Nightscout and hid it — until the event
type started being derived from `carbsInput`, at which point the same carb-free
bolus landed a second time as a `Correction Bolus` beside the `Meal Bolus` it
had been stored as before. **Insulin on board then counts it twice.**

`bookmark.seenGuids` is only created when a source actually supplies guids, so
the persisted bookmark shape is unchanged for sources that do not.

## devicestatus

The IOB record is derived from the newest bolus in the window, so the same one
is produced every poll, and Nightscout does not deduplicate devicestatus.
Records are now filtered against `bookmark.devicestatus`, which upstream already
seeds and refreshes — no new bookmark key.

## Deliberately not included

- **Timestamp conversion** is left exactly as upstream has it. DST correctness
  is #58's subject; that PR does it with `Intl` and no new dependency, which is
  the right approach, and duplicating it here would only conflict.
- **Food import and carb-gap flagging.** Implemented, but the account they were
  written against logs no food, so the code path runs with no input and I cannot
  demonstrate them working. Better as a follow-up from someone who can.

## Testing

```
upstream main        47 tests, 47 pass
this branch          47 tests, 47 pass
```

`test/glooko.test.js` is updated: the fake transport did not know about the
endpoints this adds, and the fetch test now asserts the full request path list
rather than a bare call count, so the wide-window basal fetch is visible in the
diff rather than implied.

Also verified against a synthetic batch that each mapping produces the expected
treatment, unmapped event types are dropped, alarms never become
`Announcement`, and every bolus carries a guid.

## Changes outside the Glooko driver

Three, all in `commands/forever.js`. Happy to split any of them out.

**Stop logging `argv`.** This is the one worth looking at. `input` is built by
merging the whole of `argv`, and under `yargs .env('CONNECT')` that includes
every `CONNECT_*` environment variable — `CONNECT_GLOOKO_PASSWORD`,
`CONNECT_SHARE_PASSWORD`, `CONNECT_API_SECRET` among them. It was then passed
straight to `console.log`:

```js
var input = Object.assign({}, argv, { kind: argv.source, ... });
console.log("CONFIGURED INPUT", input);   // every credential, on stdout
```

It now logs the shape instead:

```js
console.log("CONFIGURED INPUT", { kind: input.kind, url: input.url, keys: Object.keys(input).length });
```

Anywhere the process log is retained — a support bundle, a hosting provider's
log view, a snippet pasted into an issue — those are credentials at rest. #61
catches this class of leak generally, but this particular one should not depend
on that being merged.

**Build the driver config through `driver.validate()`** so `baseURL` is
populated in standalone mode. Without it the URLs are null and every collection
falls through to the empty branch, which is indistinguishable from the endpoint
returning nothing.

**Raise the STOP timer from 5 minutes**, which made `forever` stop after five
minutes.