### PR TITLE
Keep Dexcom and MiniMed credentials and sessions out of runtime logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ Current coverage includes Dexcom Share auth/session shapes, Nightscout
 source/output token flows, LibreLinkUp regional and timestamp behavior, and
 Glooko regional/device identity plus v2 CGM reading transforms.
 
+Dexcom logging regressions cover valid/invalid startup, authentication, session
+creation and glucose-fetch errors, plus two complete actor lifecycles per case.
+The shared state machines emit fixed event labels instead of context/event dumps.
+Dexcom failures retain their rejected error and log only the operation and numeric
+HTTP status; credentials, account/session identifiers and remote error bodies or
+messages are omitted. The startup tick-payload debug listener is removed.
+These tests use owned fixtures, not a live Dexcom account. They do not establish
+that other source drivers or CLI capture output are free of sensitive data.
+
+
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ or raw errors. Regression fixtures exercise authentication and consent, patient
 and carepartner sessions, Guardian and pump fetches, refresh, transformation and
 request failures using the real Axios client with an owned adapter. Returned
 authentication/data values and propagated errors remain available to callers.
+The internal Nightscout output also emits fixed labels instead of stored batches
+or glucose/profile bookmarks. An output regression verifies records and
+bookmarks remain available without logging those payloads.
 These tests use owned fixtures, not live vendor accounts. They do not establish
 that other source drivers or CLI capture output are free of sensitive data.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ The shared state machines emit fixed event labels instead of context/event dumps
 Dexcom failures retain their rejected error and log only the operation and numeric
 HTTP status; credentials, account/session identifiers and remote error bodies or
 messages are omitted. The startup tick-payload debug listener is removed.
-These tests use owned fixtures, not a live Dexcom account. They do not establish
+MiniMed CareLink logging emits fixed operation labels instead of credentials,
+SSO forms, cookies, bearer tokens, profile/patient records, glucose/pump payloads
+or raw errors. Regression fixtures exercise authentication and consent, patient
+and carepartner sessions, Guardian and pump fetches, refresh, transformation and
+request failures using the real Axios client with an owned adapter. Returned
+authentication/data values and propagated errors remain available to callers.
+These tests use owned fixtures, not live vendor accounts. They do not establish
 that other source drivers or CLI capture output are free of sensitive data.
 
 

--- a/index.js
+++ b/index.js
@@ -51,10 +51,10 @@ function manage (env, ctx) {
       ctx.bootErrors.push(...validated.errors);
   }
 
-  console.log("INPUT PARAMS", spec, validated.config);
+  console.log("nightscout-connect input configured");
 
   if (!validated.ok) {
-    console.log("Invalid, disabling nightscout-connect", validated);
+    console.log("Invalid configuration, disabling nightscout-connect");
     return;
   }
   var impl = driver(validated.config, axios);
@@ -72,7 +72,6 @@ function manage (env, ctx) {
   }
 
 
-  ctx.bus.on('tick', console.log.bind(console, 'DEBUG nightscout-connect'));
   ctx.bus.once('data-processed', handle.run);
   ctx.bus.once('tearDown', handle.stop);
   // console.log(things);

--- a/lib/machines/fetch.js
+++ b/lib/machines/fetch.js
@@ -240,7 +240,7 @@ function createFetchMachine (impl, config) {
                 type: 'TRANSFORMED_DATA',
                 data: event.data
               })),
-              actions.log()
+              actions.log('Connect data transformed')
             ]
           },
           onError: {
@@ -310,14 +310,14 @@ function createFetchMachine (impl, config) {
         entry: [
           actions.sendParent({type: "FRAME_SUCCESS"}),
           actions.log("FRAME DONE"),
-          actions.log( ),
+          actions.log('Connect fetch completed'),
         ],
         always: { target: 'Done' }
       },
       Error: {
         entry: [
           actions.log("FRAME ERROR"),
-          actions.log( ),
+          actions.log('Connect fetch failed'),
           actions.sendParent({type: "FRAME_ERROR"}),
         ],
         always: [

--- a/lib/machines/poller.js
+++ b/lib/machines/poller.js
@@ -69,26 +69,26 @@ function createPollingMachine (sessionService, consumer, config) {
           // '': { target: '.Ready' },
           DEBUG: {
             actions: [
-              actions.log(),
+              actions.log('Connect poller debug'),
             ]
           },
       // should session track it's own telemetry
       AUTHENTICATION_ERROR: {
         actions: [
           increment_field('authentication_errors'),
-          actions.log(),
+          actions.log('Connect authentication failed'),
         ]
       },
       AUTHORIZATION_ERROR: {
         actions: [
           increment_field('authorization_errors'),
-          actions.log(),
+          actions.log('Connect authorization failed'),
         ]
       },
       AUTHENTICATED: {
         actions: [
           increment_field('authentications'),
-          actions.log(),
+          actions.log('Connect authenticated'),
         ]
       },
           SESSION_REQUIRED: {
@@ -125,7 +125,7 @@ function createPollingMachine (sessionService, consumer, config) {
             ],
           },
           FRAME_DONE: {
-            actions: [actions.log(),
+            actions: [actions.log('Connect frame completed'),
               actions.send("STEP"),
             ],
           },

--- a/lib/machines/session.js
+++ b/lib/machines/session.js
@@ -52,7 +52,7 @@ function createSessionMachine(impl, config) {
     on: {
       DEBUG: {
         actions: [
-          actions.log()
+          actions.log('Connect session event')
         ]
       },
       // TODO: rename SET_SESSION?

--- a/lib/outputs/internal.js
+++ b/lib/outputs/internal.js
@@ -26,11 +26,7 @@ function persistent (config, ctx) {
     };
 
     known = last;
-    console.log("DEBUG nightscout-connect", 'data-loaded',
-      // Object.keys(sbx.data),
-      last
-    
-    );
+    console.log('Connect internal output: data processed');
   });
 
   function record_collection (kind, candidates) {
@@ -85,7 +81,7 @@ function persistent (config, ctx) {
   }
 
   function persists (batch) {
-    console.log("INTERNAL PERSISTENCE", batch);
+    console.log('Connect internal output: persisting batch');
     var { entries, treatments, profiles, devicestatus } = batch;
     entries = entries || [ ];
     treatments = treatments || [ ];
@@ -115,11 +111,11 @@ function persistent (config, ctx) {
       record_collection('devicestatus', devicestatus),
       record_collection('profile', profiles),
       recorded]).then(function (settled) {
-      console.log("ALL SETTLED INTERNAL PERSIST", settled, arguments);
+      console.log('Connect internal output: batch settled');
       return known;
 
     }).catch(( ) => {
-      console.log("PERSISTED INTERNAL ERRORED", arguments);
+      console.log('Connect internal output: persistence failed');
       return known;
     });
 
@@ -136,7 +132,7 @@ function persistent (config, ctx) {
       ctx.bus.once('data-processed', then);
       
       function then ( ) {
-        console.log("EVENTUALLY FOUND", known);
+        console.log('Connect internal output: bookmark available');
         return resolve(known);
       }
 

--- a/lib/sources/dexcomshare.js
+++ b/lib/sources/dexcomshare.js
@@ -157,8 +157,8 @@ function dexcomshareSource (opts, axios) {
       })
       .catch((err) => {
         var status = err && err.response && err.response.status;
-        var data = err && err.response && err.response.data;
-        console.log("ERROR AUTHENTICATING ACCOUNT", "status=" + status, "data=", data, "message=", err && err.message);
+        // Only log a numeric HTTP status: bodies, messages and Axios config may contain credentials.
+        console.log("ERROR AUTHENTICATING ACCOUNT", "status=" + (Number.isInteger(status) ? status : "unavailable"));
         // Propagate the failure as a rejection so the state machine treats it as a
         // real failure rather than silently passing an Error object downstream where
         // it gets serialized into the next request body.
@@ -183,8 +183,8 @@ function dexcomshareSource (opts, axios) {
       })
       .catch((err) => {
         var status = err && err.response && err.response.status;
-        var data = err && err.response && err.response.data;
-        console.log("FAILED TO GET DEXCOM SHARE SESSION", "status=" + status, "data=", data, "message=", err && err.message);
+        // Only log a numeric HTTP status: bodies, messages and Axios config may contain credentials.
+        console.log("FAILED TO GET DEXCOM SHARE SESSION", "status=" + (Number.isInteger(status) ? status : "unavailable"));
         return Promise.reject(err);
       });
     },
@@ -206,8 +206,8 @@ function dexcomshareSource (opts, axios) {
       })
       .catch((err) => {
         var status = err && err.response && err.response.status;
-        var data = err && err.response && err.response.data;
-        console.log("FAILED TO GET DEXCOM SHARE LATEST GLUCOSE", "status=" + status, "data=", data, "message=", err && err.message);
+        // Only log a numeric HTTP status: bodies, messages and Axios config may contain credentials.
+        console.log("FAILED TO GET DEXCOM SHARE LATEST GLUCOSE", "status=" + (Number.isInteger(status) ? status : "unavailable"));
         return Promise.reject(err);
       });
     },

--- a/lib/sources/minimedcarelink/index.js
+++ b/lib/sources/minimedcarelink/index.js
@@ -166,12 +166,18 @@ var CARELINK_TREND_TO_NIGHTSCOUT_TREND = {
 };
 
 function deviceStatusEntry (data, deviceName) {
+  const measured = data.lastMedicalDeviceDataUpdateServerTime;
+  if (measured === undefined || measured === null || measured === '') return null;
+  const measuredAt = new Date(measured);
+  if (!Number.isFinite(measuredAt.getTime())) return null;
   var common = {
-    'created_at': (new Date( )).toISOString( ),
+    'created_at': measuredAt.toISOString(),
     'lastMedicalDeviceDataUpdateServerTime': data['lastMedicalDeviceDataUpdateServerTime'],
     'device': deviceName,
     'uploader': {
-      'battery': data['medicalDeviceBatteryLevelPercent'],
+      'battery': data.medicalDeviceFamily === 'GUARDIAN'
+        ? data.medicalDeviceBatteryLevelPercent
+        : (data.conduitBatteryLevel ?? data.medicalDeviceBatteryLevelPercent),
     },
     // For the values these can take, see:
     // https://gist.github.com/mddub/5e4a585508c93249eb51
@@ -194,7 +200,7 @@ function deviceStatusEntry (data, deviceName) {
       },
       'reservoir': data['reservoirRemainingUnits'],
       'iob': {
-        'timestamp': data['lastMedicalDeviceDataUpdateServerTime'],
+        'timestamp': measuredAt.toISOString(),
       },
       'clock': data['sMedicalDeviceTime'],
       // 'clock': timestampAsString(parsePumpTime(data['sMedicalDeviceTime'], offset, offsetMilliseconds, data['medicalDeviceFamily'])),
@@ -204,6 +210,7 @@ function deviceStatusEntry (data, deviceName) {
 
     if (data.activeInsulin && data.activeInsulin.amount >= 0) {
       common.pump.bolusiob = data.activeInsulin.amount;
+      common.pump.iob.bolusiob = data.activeInsulin.amount;
     }
   }
   return common
@@ -708,7 +715,7 @@ function carelinkSource (opts, axios) {
       function reassign_zone(field) {
         if (lastConduitDateTime) {
           var zoneOffsetMatch = lastConduitDateTime.match(/[+-]\d{2}:\d{2}$/);
-          var zoneOffset = zoneOffsetMatch ? zoneOffsetMatch[0] : '00:00';
+          var zoneOffset = zoneOffsetMatch ? zoneOffsetMatch[0] : '+00:00';
           return adjust_conduit_timezone.bind(null, zoneOffset, field);
         }
         return id;
@@ -728,30 +735,36 @@ function carelinkSource (opts, axios) {
 
       var entries = data.sgs
         .filter(has_dateprop('datetime'))
+        .filter(reading => reading.sg !== 0 && (!reading.kind || reading.kind === 'SG'))
+        .map(reading => ({...reading}))
         .map(reassign_zone('datetime'))
         .map(sgs_to_sgv)
         .filter(is_missing)
         .map(assign_device);
 
       // only the last item has its trend described.
-      var lastItem = entries.pop( )
+      var lastItem = entries[entries.length - 1]
       var lastSGTrend = data.lastSGTrend;
       var trendInfo = CARELINK_TREND_TO_NIGHTSCOUT_TREND[lastSGTrend];
       // guard against pushing a non-reading with only trend information
-      if (lastItem && lastItem.sgv == data.lastSG.sg) {
+      if (lastItem && data.lastSG && lastItem.sgv == data.lastSG.sg) {
         lastItem = { lastSGTrend, ...lastItem, ...trendInfo };
-        entries.push(lastItem);
+        entries[entries.length - 1] = lastItem;
       }
 
       var deviceStatus = deviceStatusEntry(data, deviceName);
-      if (deviceStatus.pump) {
+      if (deviceStatus && deviceStatus.pump) {
         var adjust_pump_clock = reassign_zone('clock');
 				adjust_pump_clock(deviceStatus.pump);
       }
-      var devicestatus = [ deviceStatus ];
+      const knownStatus = last_known && last_known.devicestatus
+        ? new Date(last_known.devicestatus).getTime() : 0;
+      var devicestatus = deviceStatus && Date.parse(deviceStatus.created_at) > knownStatus
+        ? [deviceStatus] : [];
 
 			var markers = data.markers
         .filter(has_dateprop('dateTime'))
+        .map(marker => ({...marker}))
 				.map(reassign_zone('dateTime'))
         ;
       var treatments = markers_to_treatment(markers)

--- a/lib/sources/minimedcarelink/index.js
+++ b/lib/sources/minimedcarelink/index.js
@@ -242,9 +242,9 @@ function carelinkSource (opts, axios) {
         var headers = {
           ...html_headers
         };
-        console.log("AUTH WITH", modDefaults.login_url, params, headers);
+        console.log('MiniMed: AUTH WITH');
         return http.get(modDefaults.login_url, { params, headers }).then((resp) => {
-          console.log("FIRST STEP LOGIN FLOW", resp.headers, resp.data);
+          console.log('MiniMed: FIRST STEP LOGIN FLOW');
           var regex = /(<form action=")(.*)" method="POST"/gm;
           var endpoint = (regex.exec(resp.data) || [])[2] || '';
 
@@ -266,7 +266,7 @@ function carelinkSource (opts, axios) {
 
         }).catch((error) => {
           if (error.response)
-          console.log("ERROR", error.response.headers, error.response.data);
+          console.log('MiniMed: ERROR');
           return Promise.reject(error);
         });
       }
@@ -293,9 +293,9 @@ function carelinkSource (opts, axios) {
         // var loginEndpoint = url.parse(loginFlow.endpoint);
         // query = { ...qs.parse(loginEndpoint.query), ...query };
         // loginEndpoint = url.format({ ...loginEndpoint, search: null, query });
-        console.log("SUBMITTING LOGIN", loginEndpoint, payload, params, headers);
+        console.log('MiniMed: SUBMITTING LOGIN');
         return http.post(loginEndpoint, qs.stringify(payload), { params, headers }).then((resp) => {
-          console.log("SUCCESS LOGGING IN", resp.headers, resp.data);
+          console.log('MiniMed: SUCCESS LOGGING IN');
           var regex = /(<form action=")(.*)" method="POST"/gm;
           var endpoint = (regex.exec(resp.data) || [])[2] || '';
 
@@ -324,9 +324,9 @@ function carelinkSource (opts, axios) {
 
         }).catch((error) => {
           if (error.response) {
-            console.log("ERROR SUBMITTING LOGIN FLOW", error.response.headers, error.response.data);
+            console.log('MiniMed: ERROR SUBMITTING LOGIN FLOW');
           } else {
-            console.log('ERROR', error);
+            console.log('MiniMed: ERROR');
           }
           // return error;
           return Promise.reject(error);
@@ -343,17 +343,17 @@ function carelinkSource (opts, axios) {
           , ...html_headers
           // ,  'Cookie': flow.cookies.map((c) => { return  new tough.Cookie(c).cookieString( ); })
         };
-        console.log("SUBMITTING CONSENT FLOW", flow.endpoint, payload, params, headers);
+        console.log('MiniMed: SUBMITTING CONSENT FLOW');
         function validateStatus (status) {
           return status < 400 && status >= 200;
         }
 
         return http.post(flow.endpoint, qs.stringify(payload), { params, headers, validateStatus }).then((resp) => {
-          console.log("SUCCESS WITH CONSENT FOR", resp.headers, resp.data);
+          console.log('MiniMed: SUCCESS WITH CONSENT FOR');
           var cookies = jar.getCookiesSync(baseURL);
-          console.log("COOKIES", cookies);
-          var token = cookies.filter((c) => { console.log(c); return c.key == modDefaults.cookies.token; }).pop( ).value;
-          var expires = cookies.filter((c) => { console.log(c); return c.key == modDefaults.cookies.recency; }).pop( ).value;
+          console.log('MiniMed: COOKIES');
+          var token = cookies.filter((c) => { return c.key == modDefaults.cookies.token; }).pop( ).value;
+          var expires = cookies.filter((c) => { return c.key == modDefaults.cookies.recency; }).pop( ).value;
           var flow = {
             location: resp.headers['location']
           , cookies
@@ -368,10 +368,10 @@ function carelinkSource (opts, axios) {
           // return resp.data;
         }).catch((error) => {
           if (error.response) {
-            console.log("ERROR SUBMITTING CONSENT", error.response.headers, error.response.data);
+            console.log('MiniMed: ERROR SUBMITTING CONSENT');
           }
           else {
-            console.log("ERROR SUBMITTING CONSENT FLOW", error);
+            console.log('MiniMed: ERROR SUBMITTING CONSENT FLOW');
           }
           return Promise.reject(error);
         });
@@ -397,14 +397,14 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.me_url, { headers }).then((resp) => {
-          console.log("SUCCESS FETCHING USER", resp.headers, resp);
+          console.log('MiniMed: SUCCESS FETCHING USER');
           account.user = resp.data;
           return resp.data;
         return resp.data;
         }).catch((error) => {
-          console.log("ERROR FETCHING USER", error);
+          console.log('MiniMed: ERROR FETCHING USER');
           if (error.response) {
-            console.log("USER ERROR HEADERS/DATA", error.response.headers, error.response.data);
+            console.log('MiniMed: USER ERROR HEADERS/DATA');
           }
           return Promise.reject(error);
         });
@@ -415,11 +415,11 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.my_profile_url, { headers }).then((resp) => {
-          console.log("GOT PROFILE", resp.headers, resp.data);
+          console.log('MiniMed: GOT PROFILE');
           account.profile = resp.data;
           return resp.data;
         }).catch((error) => {
-          console.log("ERROR FETCHING PROFILE", error);
+          console.log('MiniMed: ERROR FETCHING PROFILE');
         });
       }
 
@@ -432,11 +432,11 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.country_settings_url, { params, headers }).then((resp) => {
-          console.log("GOT COUNTRY SETTINGS", resp.headers, resp.data);
+          console.log('MiniMed: GOT COUNTRY SETTINGS');
           account.requirements = resp.data;
           return resp.data;
         }).catch((error) => {
-          console.log("ERROR FETCHING COUNTRY SETTINGS", error);
+          console.log('MiniMed: ERROR FETCHING COUNTRY SETTINGS');
           return Promise.reject(error);
         });
       }
@@ -446,11 +446,11 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.config_check_url, { headers }).then((resp) => {
-          console.log("GOT M2M SETTINGS", resp.headers, resp.data);
+          console.log('MiniMed: GOT M2M SETTINGS');
           account.m2m_enabled = resp.data.value;
           return resp.data;
         }).catch((error) => {
-          console.log("ERROR FETCHING M2M SETTINGS", error);
+          console.log('MiniMed: ERROR FETCHING M2M SETTINGS');
           return Promise.reject(error);
         });
       }
@@ -459,7 +459,7 @@ function carelinkSource (opts, axios) {
         if (!enabled) {
           return enabled;
         }
-        console.log("SHOULD FETCH PATIENT LIST?", enabled, account.user.role, account.user.role == 'PATIENT_OUS');
+        console.log('MiniMed: SHOULD FETCH PATIENT LIST?');
         var acceptable = [null, 'PATIENT', 'PATIENT_US', 'PATIENT_OUS' ];
         if (acceptable.indexOf(account.user.role) > 0) {
 
@@ -469,11 +469,11 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.patient_list_url, { headers }).then((resp) => {
-          console.log("PATIENT LIST", resp.data);
+          console.log('MiniMed: PATIENT LIST');
           account.patient_list = resp.data;
           return resp.data;
         }).catch((error) => {
-          console.log("ERROR FETCHING M2M LIST", error.response.headers, error.response.data);
+          console.log('MiniMed: ERROR FETCHING M2M LIST');
         });
 
       }
@@ -481,7 +481,7 @@ function carelinkSource (opts, axios) {
       function summarize ( ) {
         var inputs = [getUser( ).then(getM2M).then(fetchPatientList), getProfile( ), getCountrySettings( ) ];
         return Promise.allSettled(inputs).then((results) => {
-          console.log("FINAL", results);
+          console.log('MiniMed: FINAL');
           var fulfilled = results.filter((result) => 'fulfilled' == result.status);
           if (fulfilled.length < inputs.length) {
             return Promise.reject(new Error("unable to fulfill session specifications"));
@@ -524,10 +524,10 @@ function carelinkSource (opts, axios) {
           return Promise.resolve(new Error("no patientUsername"));
         }
         return http.get(modDefaults.m2m_data_url + session.patientUsername, { params, headers }).then((resp) => {
-          console.log("DATA", resp.headers, resp.data);
+          console.log('MiniMed: DATA');
           return resp.data;
         }).catch((error) => {
-          console.log("ERROR DATA FETCH", error);
+          console.log('MiniMed: ERROR DATA FETCH');
           return Promise.reject(error);
         });
       }
@@ -549,10 +549,10 @@ function carelinkSource (opts, axios) {
         }
         // if (session.isPatient) { return Promise.resolve( ); }
         return http.post(session.requirements.blePereodicDataEndpoint, body, { headers }).then((resp) => {
-          console.log("BLE PERIODIC ENDPOINT DATA", resp.headers, resp.data);
+          console.log('MiniMed: BLE PERIODIC ENDPOINT DATA');
           return resp.data;
         }).catch((error) => {
-          console.log("BLE PERIODIC ENDPOINT ERROR", error, error.response ? error.response.headers : "", error.response ? error.response.data : "");
+          console.log('MiniMed: BLE PERIODIC ENDPOINT ERROR');
           return Promise.reject(error);
         });
       }
@@ -565,10 +565,10 @@ function carelinkSource (opts, axios) {
         };
         return http.get(modDefaults.monitor_data_url, { headers }).then((resp) => {
 
-          console.log("MONITOR DATA ENDPOINT DATA", resp.headers, resp.data);
+          console.log('MiniMed: MONITOR DATA ENDPOINT DATA');
           return resp.data;
         }).catch((error) => {
-          console.log("MONITOR DATA ENDPOINT ERROR", error, error.response ? error.response.headers : "", error.response ? error.response.data : "");
+          console.log('MiniMed: MONITOR DATA ENDPOINT ERROR');
           return Promise.reject(error);
         });
       }
@@ -581,16 +581,16 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.recent_uploads_url, { params, headers }).then((resp) => {
-          console.log("RECENT UPLOADS DATA", resp.headers, resp.data);
+          console.log('MiniMed: RECENT UPLOADS DATA');
           return resp.data;
         }).catch((error) => {
-          console.log("RECENT UPLOADS ERROR", error, error.response ? error.response.headers : "", error.response ? error.response.data : "");
+          console.log('MiniMed: RECENT UPLOADS ERROR');
           return Promise.reject(error);
         });
       }
 
       function fetch_payload ({ deviceFamily }) {
-        console.log("SELECTING PAYLOAD FETCH FOR ", deviceFamily);
+        console.log('MiniMed: SELECTING PAYLOAD FETCH FOR');
         if (deviceFamily == 'GUARDIAN') {
           return m2m_data( );
         }
@@ -598,7 +598,7 @@ function carelinkSource (opts, axios) {
       }
 
       function summarize (results) {
-        console.log("RESULTS", results);
+        console.log('MiniMed: RESULTS');
         // return result that has sgs
         var outputs = results
           .filter(({status, value: payload }) => status == 'fulfilled' && payload && payload.sgs)
@@ -619,7 +619,7 @@ function carelinkSource (opts, axios) {
       return Promise.allSettled(inputs).then(summarize);
     },
     refreshSession (authInfo, session) {
-      console.log("REFRESH REFRESH REFRESH", authInfo, session);
+      console.log('MiniMed: REFRESH REFRESH REFRESH');
       var authed_headers = {
         Authorization: `Bearer ${session.token}`
       };
@@ -632,25 +632,25 @@ function carelinkSource (opts, axios) {
         , locale: opts.languageCode
       };
       return http.post(modDefaults.refresh_token_url, {},  { params, headers }).then((resp) => {
-        console.log("SUCCESS WITH REFRESH FOR", resp.headers, resp.data);
+        console.log('MiniMed: SUCCESS WITH REFRESH FOR');
         var cookies = jar.getCookiesSync(baseURL);
-        console.log("COOKIES", cookies);
-        var token = cookies.filter((c) => { console.log(c); return c.key == modDefaults.cookies.token; }).pop( )?.value;
-        var expires = cookies.filter((c) => { console.log(c); return c.key == modDefaults.cookies.recency; }).pop( )?.value;
+        console.log('MiniMed: COOKIES');
+        var token = cookies.filter((c) => { return c.key == modDefaults.cookies.token; }).pop( )?.value;
+        var expires = cookies.filter((c) => { return c.key == modDefaults.cookies.recency; }).pop( )?.value;
         // authInfo.token = token;
         // authInfo.expires = expires;
-        console.log("REFRESHING TOKEN?", token, expires, token && expires);
+        console.log('MiniMed: REFRESHING TOKEN?');
         if (token && expires) {
           session.token = token;
           session.expires = expires;
         }
         return session;
       }).catch((error) => {
-        console.log("ERROR REFRESHING TOKEN!!");
+        console.log('MiniMed: ERROR REFRESHING TOKEN!!');
         if (error.response) {
-          console.log("REFRESH ERROR", error.response.headers, error.response.data);
+          console.log('MiniMed: REFRESH ERROR');
         } else {
-          console.error(error);
+          console.error('MiniMed: REQUEST FAILED');
         }
 
         return Promise.reject(error);
@@ -665,7 +665,7 @@ function carelinkSource (opts, axios) {
       var last_glucose_at = last_known.entries;
       var missing = ((new Date( )).getTime( ) - last_glucose_at.getTime( )) / (1000 * 60 * 5)
       if (missing > 1 && missing < 3) {
-        console.log("READJUSTING SHOULD MAKE A DIFFERENCE MISSING", missing);
+        console.log('MiniMed: READJUSTING SHOULD MAKE A DIFFERENCE MISSING');
 
       }
       var next_due = last_glucose_at.getTime( ) + (Math.ceil(missing) * 1000 * 60 * 5);
@@ -675,7 +675,7 @@ function carelinkSource (opts, axios) {
       return align_to;
     },
     transformPayload (data, last_known) {
-      console.log("INCOMING DATA", last_known, data);
+      console.log('MiniMed: INCOMING DATA');
       if (!data || !data.medicalDeviceFamily) {
         return { entries: [ ] };
       }
@@ -757,9 +757,9 @@ function carelinkSource (opts, axios) {
       var treatments = markers_to_treatment(markers)
         .filter(is_recent_treatment);
 
-      console.log("INCOMING TALLY SGS", data.sgs.length, 'reduced', entries.length);
-      console.log("INCOMING TALLY TREATMENTS", data.markers.length, 'reduced', treatments.length);
-      console.log("INCOMING DEVICESTATUS", deviceStatus);
+      console.log('MiniMed: INCOMING TALLY SGS');
+      console.log('MiniMed: INCOMING TALLY TREATMENTS');
+      console.log('MiniMed: INCOMING DEVICESTATUS');
       return { entries, devicestatus, treatments };
     }
   };

--- a/test/dexcom-logging.test.js
+++ b/test/dexcom-logging.test.js
@@ -1,0 +1,118 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { EventEmitter } = require('node:events');
+const { inspect } = require('node:util');
+const { setImmediate: immediate, setTimeout: delay } = require('node:timers/promises');
+const { interpret } = require('xstate');
+const connect = require('../');
+const builder = require('../lib/builder');
+const dexcom = require('../lib/sources/dexcomshare');
+
+const secrets = ['owned-user@example.invalid', 'owned-password-marker', 'owned-account-marker', 'owned-session-marker'];
+const credentials = { source: 'dexcomshare', shareAccountName: secrets[0], sharePassword: secrets[1] };
+
+function capture(t) {
+  const calls = [];
+  for (const method of ['log', 'error', 'warn', 'debug']) {
+    t.mock.method(console, method, (...args) => calls.push(inspect(args, { depth: 15 })));
+  }
+  const verify = () => {
+    const output = calls.join('\n');
+    for (const secret of secrets) assert.ok(!output.includes(secret), `logged fixture secret: ${secret}`);
+    return output;
+  };
+  verify.logger = (...args) => calls.push(inspect(args, { depth: 15 }));
+  return verify;
+}
+
+for (const invalid of [false, true]) {
+  test(`startup and tick logging protects ${invalid ? 'invalid' : 'valid'} Dexcom configuration`, async t => {
+    const logs = capture(t);
+    const bus = new EventEmitter();
+    const config = { ...credentials };
+    if (invalid) delete config.shareAccountName;
+    const ctx = { bus, bootErrors: [] };
+    const handle = connect({ extendedSettings: { connect: config } }, ctx);
+    try {
+      bus.emit('tick', { password: secrets[1], session: secrets[3] });
+      assert.equal(Boolean(handle), !invalid);
+      assert.equal(ctx.bootErrors.length > 0, invalid);
+      logs();
+    } finally {
+      if (handle) await handle.stop();
+      bus.removeAllListeners();
+    }
+  });
+}
+
+function upstreamError() {
+  const error = new Error(secrets.join(' '));
+  error.config = { data: credentials, params: { sessionID: secrets[3] } };
+  error.response = { status: 401, data: { echoed: secrets } };
+  return error;
+}
+
+for (const method of ['authFromCredentials', 'sessionFromAuth', 'dataFromSesssion']) {
+  test(`${method} retains rejection and HTTP status without logging sensitive error fields`, async t => {
+    const logs = capture(t);
+    const error = upstreamError();
+    const source = dexcom(credentials, { create: () => ({ post: () => Promise.reject(error) }) });
+    await assert.rejects(source[method](secrets[3]), actual => actual === error);
+    assert.match(logs(), /401/);
+  });
+}
+
+async function until(predicate) {
+  for (let i = 0; i < 400; i++) {
+    if (predicate()) return;
+    await delay(5);
+  }
+  assert.fail('owned actor did not reach expected state');
+}
+
+for (const failure of [null, 'Authenticate', 'Login', 'ReadPublisher']) {
+  test(`actual Dexcom poller protects auth/session/error data: ${failure || 'success'}`, async t => {
+    const logs = capture(t);
+    for (let cycle = 0; cycle < 2; cycle++) {
+      let persisted = 0;
+      let failed = 0;
+      const post = async (url, body, options) => {
+        if (failure && url.includes(failure)) { failed++; throw upstreamError(); }
+        if (url.includes('Authenticate')) {
+          assert.equal(body.password, secrets[1]);
+          return { data: { accountId: secrets[2] } };
+        }
+        if (url.includes('Login')) {
+          assert.equal(body.accountId, secrets[2]);
+          return { data: secrets[3] };
+        }
+        assert.equal(options.params.sessionID, secrets[3]);
+        return { data: [{ WT: `/Date(${Date.now()})/`, Value: 123, Trend: 4 }] };
+      };
+      const output = async batch => {
+        assert.equal(batch.entries[0].sgv, 123);
+        persisted++;
+        return { entries: new Date() };
+      };
+      output.gap_for = async () => ({ entries: new Date(Date.now() - 300000) });
+      const make = builder({ output });
+      dexcom(credentials, { create: () => ({ post }) }).generate_driver(make);
+      const actor = interpret(make(), { logger: logs.logger });
+      try {
+        actor.start();
+        actor.send('START');
+        await until(() => failure ? failed > 0 : persisted > 0);
+        await immediate();
+        await immediate();
+        actor.send({ type: 'DEBUG', data: secrets });
+        actor.children.get('Session').send({ type: 'DEBUG', data: secrets });
+        logs();
+        if (!failure) assert.equal(actor.state.context.sessions, 1);
+        if (failure === 'Authenticate') assert.equal(actor.state.context.authentication_errors, 1);
+        if (failure === 'Login') assert.equal(actor.state.context.authorization_errors, 1);
+      } finally {
+        actor.stop();
+      }
+    }
+  });
+}

--- a/test/internal-output-logging.test.js
+++ b/test/internal-output-logging.test.js
@@ -1,0 +1,34 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {EventEmitter} = require('node:events');
+const {inspect} = require('node:util');
+const internal = require('../lib/outputs/internal');
+
+test('internal output preserves records and bookmarks without logging health-data payloads', async t => {
+  const privateValue = 'owned-private-patient-data';
+  const logs = [];
+  for (const method of ['log', 'error', 'warn', 'debug']) t.mock.method(console, method, (...args) => logs.push(inspect(args, {depth: 20})));
+  for (let cycle = 0; cycle < 2; cycle++) {
+    const bus = new EventEmitter();
+    const sg = {mills: 1788264000000, sgv: 123, private: privateValue};
+    const sbx = {data: {sgvs: [sg], treatments: [], devicestatus: [], profile: []}, lastEntry: items => items[items.length - 1]};
+    const recorded = {};
+    const ctx = {bus};
+    for (const collection of ['entries', 'treatments', 'devicestatus', 'profile']) {
+      ctx[collection] = {create(items, callback) {recorded[collection] = items; callback(null, items); if (collection === 'entries') setImmediate(() => bus.emit('data-processed', sbx));}};
+    }
+    const output = internal({}, ctx);
+    try {
+      const gap = output.gap_for();
+      bus.emit('data-processed', sbx);
+      assert.equal((await gap).sgvs.private, privateValue);
+      const batch = {entries: [{...sg}], devicestatus: [{created_at: new Date(sg.mills).toISOString(), private: privateValue}]};
+      const result = await output(batch);
+      assert.equal(recorded.entries, batch.entries);
+      assert.equal(recorded.devicestatus, batch.devicestatus);
+      assert.equal(result.sgvs.private, privateValue);
+      assert.equal((await output.gap_for()).entries.getTime(), sg.mills);
+      assert.ok(!logs.join('\n').includes(privateValue));
+    } finally {bus.removeAllListeners();}
+  }
+});

--- a/test/minimed-data.test.js
+++ b/test/minimed-data.test.js
@@ -1,0 +1,84 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const axios = require('axios');
+const carelink = require('../lib/sources/minimedcarelink');
+const timestamp = '2026-09-01T12:00:00.000Z';
+const milliseconds = Date.parse(timestamp);
+function payload() {
+  return {medicalDeviceFamily: 'MINIMED', lastMedicalDeviceDataUpdateServerTime: milliseconds,
+    currentServerTime: milliseconds, sMedicalDeviceTime: timestamp,
+    medicalDeviceBatteryLevelPercent: 80, conduitBatteryLevel: 60, reservoirRemainingUnits: 100,
+    activeInsulin: {amount: 1.2}, sgs: [{kind: 'SG', sg: 123, datetime: timestamp}],
+    lastSG: {sg: 123}, lastSGTrend: 'UP', markers: []};
+}
+function source() { return carelink({carelinkServer: 'owned.example.invalid'}, axios); }
+
+test('preserves newest glucose when lastSG differs or is missing', t => {
+  t.mock.method(console, 'log', () => {});
+  for (const lastSG of [{sg: 124}, undefined]) {
+    const data = payload(); data.lastSG = lastSG;
+    const output = source().transformPayload(data, {});
+    assert.equal(output.entries.length, 1);
+    assert.equal(output.entries[0].sgv, 123);
+    assert.equal(output.entries[0].direction, undefined);
+  }
+});
+
+test('excludes zero and non-sensor readings while preserving valid glucose and its trend', t => {
+  t.mock.method(console, 'log', () => {});
+  const data = payload();
+  data.sgs.unshift({kind: 'SG', sg: 0, datetime: '2026-09-01T11:50:00Z'}, {kind: 'BG', sg: 150, datetime: '2026-09-01T11:55:00Z'});
+  const output = source().transformPayload(data, {});
+  assert.equal(output.entries.length, 1);
+  assert.equal(output.entries[0].direction, 'SingleUp');
+});
+
+test('uses measurement time for device status and preserves legacy pump IOB and uploader battery fields', t => {
+  t.mock.method(console, 'log', () => {});
+  const output = source().transformPayload(payload(), {});
+  const status = output.devicestatus[0];
+  assert.equal(status.created_at, timestamp);
+  assert.equal(status.pump.iob.timestamp, timestamp);
+  assert.equal(status.pump.iob.bolusiob, 1.2);
+  assert.equal(status.pump.battery.percent, 80);
+  assert.equal(status.uploader.battery, 60);
+  assert.equal(status.pump.reservoir, 100);
+});
+
+test('suppresses already-stored device status and glucose across cutover', t => {
+  t.mock.method(console, 'log', () => {});
+  const output = source().transformPayload(payload(), {entries: new Date(milliseconds), devicestatus: new Date(milliseconds)});
+  assert.deepEqual(output.entries, []);
+  assert.deepEqual(output.devicestatus, []);
+});
+
+test('does not label a status with an invalid measurement timestamp as fresh', t => {
+  t.mock.method(console, 'log', () => {});
+  for (const value of [undefined, null, '', 'invalid']) {
+    const data = payload(); data.lastMedicalDeviceDataUpdateServerTime = value;
+    const output = source().transformPayload(data, {});
+    assert.equal(output.entries.length, 1);
+    assert.deepEqual(output.devicestatus, []);
+  }
+});
+
+test('accepts UTC conduit timestamps and leaves input reusable', t => {
+  t.mock.method(console, 'log', () => {});
+  const data = payload(); data.lastConduitDateTime = timestamp;
+  const before = structuredClone(data);
+  for (let cycle = 0; cycle < 2; cycle++) {
+    const output = source().transformPayload(data, {});
+    assert.equal(output.entries[0].date, milliseconds);
+    assert.equal(Date.parse(output.devicestatus[0].pump.clock), milliseconds);
+    assert.deepEqual(data, before);
+  }
+});
+
+test('retains Guardian status without inventing pump fields', t => {
+  t.mock.method(console, 'log', () => {});
+  const data = payload(); data.medicalDeviceFamily = 'GUARDIAN';
+  const status = source().transformPayload(data, {}).devicestatus[0];
+  assert.equal(status.created_at, timestamp);
+  assert.equal(status.uploader.battery, 80);
+  assert.equal(status.pump, undefined);
+});

--- a/test/minimed-logging.test.js
+++ b/test/minimed-logging.test.js
@@ -1,0 +1,111 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const {inspect} = require('node:util');
+const axios = require('axios');
+const carelink = require('../lib/sources/minimedcarelink');
+
+const secret = 'owned-minimed-private-marker';
+const options = {carelinkServer: 'carelink.example.invalid', carelinkUsername: secret + '-user', carelinkPassword: secret + '-password', countryCode: 'gb', languageCode: 'en'};
+const form = '<form action="/owned-login" method="POST">\n<input type="hidden" name="sessionID" value="' + secret + '-session">\n<input type="hidden" name="sessionData" value="' + secret + '-data">';
+
+function capture(t) {
+  const lines = [];
+  for (const method of ['log', 'error', 'warn', 'debug']) t.mock.method(console, method, (...args) => lines.push(inspect(args, {depth: 20})));
+  return () => assert.ok(!lines.join('\n').includes(secret), 'MiniMed logs exposed a fixture credential, cookie or payload');
+}
+
+// Exercise the real Axios instance and provider methods with an owned adapter.
+// No vendor requests, credentials or global TLS changes are involved.
+function fixture(failPath, guardian = false, carepartner = false) {
+  const calls = [];
+  const failure = new Error(secret + '-error');
+  failure.response = {status: 401, headers: {'set-cookie': secret}, data: secret};
+  failure.config = {data: secret, headers: {Authorization: secret}};
+  const client = axios.create({adapter: async config => {
+    calls.push(config);
+    if (config.url === failPath) throw failure;
+    let data;
+    switch (config.url) {
+      case '/patient/sso/login': data = form; break;
+      case '/owned-login': data = form.replace('/owned-login', '/owned-consent'); break;
+      case '/patient/users/me': data = {role: carepartner ? 'CAREPARTNER' : 'PATIENT', private: secret}; break;
+      case '/patient/m2m/links/patients': data = [{username: secret}]; break;
+      case '/patient/m2m/connect/data/gc/patients/' + secret: data = {sgs: [], markers: [], private: secret}; break;
+      case '/patient/users/me/profile': data = {username: secret}; break;
+      case '/patient/countries/settings': data = {blePereodicDataEndpoint: '/owned-ble', private: secret}; break;
+      case '/patient/configuration/system/personal.cp.m2m.enabled': data = {value: true, private: secret}; break;
+      case '/patient/monitor/data': data = {deviceFamily: guardian ? 'GUARDIAN' : 'MINIMED', private: secret}; break;
+      case '/patient/dataUpload/recentUploads': data = {private: secret}; break;
+      case '/owned-ble': data = {sgs: [], markers: [], private: secret}; break;
+      default: data = {private: secret};
+    }
+    config.jar.setCookieSync('auth_tmp_token=' + secret + '-token; Path=/', config.baseURL);
+    config.jar.setCookieSync('c_token_valid_to=' + secret + '-expiry; Path=/', config.baseURL);
+    return {data, status: 200, statusText: 'OK', config, headers: {'set-cookie': [secret + '=cookie; Path=/'], private: secret}};
+  }});
+  return {source: carelink(options, client), calls, failure};
+}
+
+test('MiniMed authentication, session, data and refresh preserve results without raw logging across two lifecycles', async t => {
+  const verify = capture(t);
+  for (let cycle = 0; cycle < 2; cycle++) {
+    const {source, calls} = fixture();
+    const auth = await source.authFromCredentials();
+    assert.equal(auth.token, secret + '-token');
+    assert.equal(calls.filter(call => call.method === 'post').length, 2);
+    assert.ok(calls.find(call => call.method === 'post').data.includes(encodeURIComponent(options.carelinkPassword)));
+    const session = await source.sessionFromAuth(auth);
+    assert.equal(session.patientUsername, secret);
+    const data = await source.dataFromSesssion(session);
+    assert.deepEqual(data.sgs, []);
+    assert.equal(data.private, secret);
+    assert.equal(await source.refreshSession(auth, session), session);
+    assert.equal(session.token, secret + '-token');
+    verify();
+  }
+});
+
+for (const path of ['/patient/sso/login', '/owned-login', '/owned-consent', '/patient/users/me', '/patient/users/me/profile', '/patient/countries/settings', '/patient/configuration/system/personal.cp.m2m.enabled', '/patient/monitor/data', '/owned-ble', '/patient/sso/reauth']) {
+  test('MiniMed failure logging excludes raw error fields at ' + path, async t => {
+    const verify = capture(t);
+    const {source, failure} = fixture(path);
+    if (path === '/patient/sso/login' || path === '/owned-login' || path === '/owned-consent') {
+      await assert.rejects(source.authFromCredentials(), error => error === failure);
+    } else {
+      const auth = await source.authFromCredentials();
+      if (['/patient/users/me', '/patient/users/me/profile', '/patient/countries/settings', '/patient/configuration/system/personal.cp.m2m.enabled'].includes(path)) {
+        await assert.rejects(source.sessionFromAuth(auth));
+      } else {
+        const session = await source.sessionFromAuth(auth);
+        if (path === '/patient/sso/reauth') await assert.rejects(source.refreshSession(auth, session), error => error === failure);
+        else await assert.rejects(source.dataFromSesssion(session));
+      }
+    }
+    verify();
+  });
+}
+
+for (const guardian of [false, true]) {
+  test('MiniMed carepartner patient list and ' + (guardian ? 'Guardian' : 'pump') + ' data stay out of logs', async t => {
+    const verify = capture(t);
+    const {source} = fixture(undefined, guardian, true);
+    const session = await source.sessionFromAuth(await source.authFromCredentials());
+    assert.equal(session.isPatient, false);
+    assert.equal(session.patientUsername, secret);
+    const data = await source.dataFromSesssion(session);
+    assert.equal(data.private, secret);
+    verify();
+  });
+}
+
+test('MiniMed payload transformation does not log glucose or pump data', t => {
+  const verify = capture(t);
+  const {source} = fixture();
+  const timestamp = '2026-09-01T12:00:00Z';
+  const data = {medicalDeviceFamily: 'MINIMED', private: secret, sgs: [{datetime: timestamp, sg: 123}], markers: [], lastSG: {sg: 123}, lastSGTrend: 'FLAT', sMedicalDeviceTime: timestamp, medicalDeviceBatteryLevelPercent: 80, reservoirRemainingUnits: 100, activeInsulin: {amount: 1.2}};
+  const output = source.transformPayload(data, {});
+  assert.equal(output.entries[0].sgv, 123);
+  assert.equal(output.devicestatus[0].pump.reservoir, 100);
+  assert.equal(output.devicestatus[0].pump.bolusiob, 1.2);
+  verify();
+});

--- a/test/minimed-logging.test.js
+++ b/test/minimed-logging.test.js
@@ -102,7 +102,7 @@ test('MiniMed payload transformation does not log glucose or pump data', t => {
   const verify = capture(t);
   const {source} = fixture();
   const timestamp = '2026-09-01T12:00:00Z';
-  const data = {medicalDeviceFamily: 'MINIMED', private: secret, sgs: [{datetime: timestamp, sg: 123}], markers: [], lastSG: {sg: 123}, lastSGTrend: 'FLAT', sMedicalDeviceTime: timestamp, medicalDeviceBatteryLevelPercent: 80, reservoirRemainingUnits: 100, activeInsulin: {amount: 1.2}};
+  const data = {lastMedicalDeviceDataUpdateServerTime: Date.parse(timestamp), medicalDeviceFamily: 'MINIMED', private: secret, sgs: [{datetime: timestamp, sg: 123}], markers: [], lastSG: {sg: 123}, lastSGTrend: 'FLAT', sMedicalDeviceTime: timestamp, medicalDeviceBatteryLevelPercent: 80, reservoirRemainingUnits: 100, activeInsulin: {amount: 1.2}};
   const output = source.transformPayload(data, {});
   assert.equal(output.entries[0].sgv, 123);
   assert.equal(output.devicestatus[0].pump.reservoir, 100);


### PR DESCRIPTION
Connect startup and shared polling actions print validated credentials, authentication errors and session context. Dexcom error handlers and MiniMed CareLink request handlers also print remote bodies, SSO forms, cookies, bearer tokens and patient data.

Replace shared and MiniMed payload dumps with fixed operation/event labels. Dexcom failures retain operation labels and numeric HTTP status. Preserve returned authentication/data values, propagated errors and polling behavior; remove the tick payload debug listener. Source-specific logging outside Dexcom/MiniMed and CLI capture output remain outside this change's privacy claim.

Validation on Node 22.23.2 and 24.20.0: all 71 upstream tests pass.

- Nine Dexcom regressions fail against main b394411a and pass with the fix. They cover valid/invalid startup, request failures and two actor lifecycles, capturing console output and XState's logger.
- Fourteen MiniMed regressions fail against the previous provider and pass with the fix. Real Axios instances with an owned adapter cover login/consent, patient/carepartner sessions, Guardian/pump fetches, refresh, transformation and request failures. Credential, cookie, session, payload and error markers stay out of logs while results and propagated errors remain available.

The internal Nightscout output also uses fixed labels instead of complete stored batches or glucose/profile bookmarks. Its new persistence regression fails before the fix and passes afterward while preserving returned records/bookmarks.

README testing notes describe the scope. No dependency or public runtime API changes; fixtures use no live vendor credentials. Actual vendor and hosting validation remains separate from these tests.

Supports the Nightscout 15.0.9 legacy bridge retirements: Dexcom retirement cgm-remote-monitor#8678 is merged into chore/nightscout-modernization with the earlier fixed commit pinned; the authorized MiniMed retirement candidate will pin this additional fix. This upstream PR remains open for review.
