### PR TITLE
Preserve MiniMed glucose and measurement-time status contracts

### DIFF
--- a/lib/sources/minimedcarelink/index.js
+++ b/lib/sources/minimedcarelink/index.js
@@ -166,12 +166,18 @@ var CARELINK_TREND_TO_NIGHTSCOUT_TREND = {
 };
 
 function deviceStatusEntry (data, deviceName) {
+  const measured = data.lastMedicalDeviceDataUpdateServerTime;
+  if (measured === undefined || measured === null || measured === '') return null;
+  const measuredAt = new Date(measured);
+  if (!Number.isFinite(measuredAt.getTime())) return null;
   var common = {
-    'created_at': (new Date( )).toISOString( ),
+    'created_at': measuredAt.toISOString(),
     'lastMedicalDeviceDataUpdateServerTime': data['lastMedicalDeviceDataUpdateServerTime'],
     'device': deviceName,
     'uploader': {
-      'battery': data['medicalDeviceBatteryLevelPercent'],
+      'battery': data.medicalDeviceFamily === 'GUARDIAN'
+        ? data.medicalDeviceBatteryLevelPercent
+        : (data.conduitBatteryLevel ?? data.medicalDeviceBatteryLevelPercent),
     },
     // For the values these can take, see:
     // https://gist.github.com/mddub/5e4a585508c93249eb51
@@ -194,7 +200,7 @@ function deviceStatusEntry (data, deviceName) {
       },
       'reservoir': data['reservoirRemainingUnits'],
       'iob': {
-        'timestamp': data['lastMedicalDeviceDataUpdateServerTime'],
+        'timestamp': measuredAt.toISOString(),
       },
       'clock': data['sMedicalDeviceTime'],
       // 'clock': timestampAsString(parsePumpTime(data['sMedicalDeviceTime'], offset, offsetMilliseconds, data['medicalDeviceFamily'])),
@@ -204,6 +210,7 @@ function deviceStatusEntry (data, deviceName) {
 
     if (data.activeInsulin && data.activeInsulin.amount >= 0) {
       common.pump.bolusiob = data.activeInsulin.amount;
+      common.pump.iob.bolusiob = data.activeInsulin.amount;
     }
   }
   return common
@@ -708,7 +715,7 @@ function carelinkSource (opts, axios) {
       function reassign_zone(field) {
         if (lastConduitDateTime) {
           var zoneOffsetMatch = lastConduitDateTime.match(/[+-]\d{2}:\d{2}$/);
-          var zoneOffset = zoneOffsetMatch ? zoneOffsetMatch[0] : '00:00';
+          var zoneOffset = zoneOffsetMatch ? zoneOffsetMatch[0] : '+00:00';
           return adjust_conduit_timezone.bind(null, zoneOffset, field);
         }
         return id;
@@ -728,30 +735,36 @@ function carelinkSource (opts, axios) {
 
       var entries = data.sgs
         .filter(has_dateprop('datetime'))
+        .filter(reading => reading.sg !== 0 && (!reading.kind || reading.kind === 'SG'))
+        .map(reading => ({...reading}))
         .map(reassign_zone('datetime'))
         .map(sgs_to_sgv)
         .filter(is_missing)
         .map(assign_device);
 
       // only the last item has its trend described.
-      var lastItem = entries.pop( )
+      var lastItem = entries[entries.length - 1]
       var lastSGTrend = data.lastSGTrend;
       var trendInfo = CARELINK_TREND_TO_NIGHTSCOUT_TREND[lastSGTrend];
       // guard against pushing a non-reading with only trend information
-      if (lastItem && lastItem.sgv == data.lastSG.sg) {
+      if (lastItem && data.lastSG && lastItem.sgv == data.lastSG.sg) {
         lastItem = { lastSGTrend, ...lastItem, ...trendInfo };
-        entries.push(lastItem);
+        entries[entries.length - 1] = lastItem;
       }
 
       var deviceStatus = deviceStatusEntry(data, deviceName);
-      if (deviceStatus.pump) {
+      if (deviceStatus && deviceStatus.pump) {
         var adjust_pump_clock = reassign_zone('clock');
 				adjust_pump_clock(deviceStatus.pump);
       }
-      var devicestatus = [ deviceStatus ];
+      const knownStatus = last_known && last_known.devicestatus
+        ? new Date(last_known.devicestatus).getTime() : 0;
+      var devicestatus = deviceStatus && Date.parse(deviceStatus.created_at) > knownStatus
+        ? [deviceStatus] : [];
 
 			var markers = data.markers
         .filter(has_dateprop('dateTime'))
+        .map(marker => ({...marker}))
 				.map(reassign_zone('dateTime'))
         ;
       var treatments = markers_to_treatment(markers)

--- a/test/minimed-data.test.js
+++ b/test/minimed-data.test.js
@@ -1,0 +1,84 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const axios = require('axios');
+const carelink = require('../lib/sources/minimedcarelink');
+const timestamp = '2026-09-01T12:00:00.000Z';
+const milliseconds = Date.parse(timestamp);
+function payload() {
+  return {medicalDeviceFamily: 'MINIMED', lastMedicalDeviceDataUpdateServerTime: milliseconds,
+    currentServerTime: milliseconds, sMedicalDeviceTime: timestamp,
+    medicalDeviceBatteryLevelPercent: 80, conduitBatteryLevel: 60, reservoirRemainingUnits: 100,
+    activeInsulin: {amount: 1.2}, sgs: [{kind: 'SG', sg: 123, datetime: timestamp}],
+    lastSG: {sg: 123}, lastSGTrend: 'UP', markers: []};
+}
+function source() { return carelink({carelinkServer: 'owned.example.invalid'}, axios); }
+
+test('preserves newest glucose when lastSG differs or is missing', t => {
+  t.mock.method(console, 'log', () => {});
+  for (const lastSG of [{sg: 124}, undefined]) {
+    const data = payload(); data.lastSG = lastSG;
+    const output = source().transformPayload(data, {});
+    assert.equal(output.entries.length, 1);
+    assert.equal(output.entries[0].sgv, 123);
+    assert.equal(output.entries[0].direction, undefined);
+  }
+});
+
+test('excludes zero and non-sensor readings while preserving valid glucose and its trend', t => {
+  t.mock.method(console, 'log', () => {});
+  const data = payload();
+  data.sgs.unshift({kind: 'SG', sg: 0, datetime: '2026-09-01T11:50:00Z'}, {kind: 'BG', sg: 150, datetime: '2026-09-01T11:55:00Z'});
+  const output = source().transformPayload(data, {});
+  assert.equal(output.entries.length, 1);
+  assert.equal(output.entries[0].direction, 'SingleUp');
+});
+
+test('uses measurement time for device status and preserves legacy pump IOB and uploader battery fields', t => {
+  t.mock.method(console, 'log', () => {});
+  const output = source().transformPayload(payload(), {});
+  const status = output.devicestatus[0];
+  assert.equal(status.created_at, timestamp);
+  assert.equal(status.pump.iob.timestamp, timestamp);
+  assert.equal(status.pump.iob.bolusiob, 1.2);
+  assert.equal(status.pump.battery.percent, 80);
+  assert.equal(status.uploader.battery, 60);
+  assert.equal(status.pump.reservoir, 100);
+});
+
+test('suppresses already-stored device status and glucose across cutover', t => {
+  t.mock.method(console, 'log', () => {});
+  const output = source().transformPayload(payload(), {entries: new Date(milliseconds), devicestatus: new Date(milliseconds)});
+  assert.deepEqual(output.entries, []);
+  assert.deepEqual(output.devicestatus, []);
+});
+
+test('does not label a status with an invalid measurement timestamp as fresh', t => {
+  t.mock.method(console, 'log', () => {});
+  for (const value of [undefined, null, '', 'invalid']) {
+    const data = payload(); data.lastMedicalDeviceDataUpdateServerTime = value;
+    const output = source().transformPayload(data, {});
+    assert.equal(output.entries.length, 1);
+    assert.deepEqual(output.devicestatus, []);
+  }
+});
+
+test('accepts UTC conduit timestamps and leaves input reusable', t => {
+  t.mock.method(console, 'log', () => {});
+  const data = payload(); data.lastConduitDateTime = timestamp;
+  const before = structuredClone(data);
+  for (let cycle = 0; cycle < 2; cycle++) {
+    const output = source().transformPayload(data, {});
+    assert.equal(output.entries[0].date, milliseconds);
+    assert.equal(Date.parse(output.devicestatus[0].pump.clock), milliseconds);
+    assert.deepEqual(data, before);
+  }
+});
+
+test('retains Guardian status without inventing pump fields', t => {
+  t.mock.method(console, 'log', () => {});
+  const data = payload(); data.medicalDeviceFamily = 'GUARDIAN';
+  const status = source().transformPayload(data, {}).devicestatus[0];
+  assert.equal(status.created_at, timestamp);
+  assert.equal(status.uploader.battery, 80);
+  assert.equal(status.pump, undefined);
+});

--- a/test/minimed-logging.test.js
+++ b/test/minimed-logging.test.js
@@ -102,7 +102,7 @@ test('MiniMed payload transformation does not log glucose or pump data', t => {
   const verify = capture(t);
   const {source} = fixture();
   const timestamp = '2026-09-01T12:00:00Z';
-  const data = {medicalDeviceFamily: 'MINIMED', private: secret, sgs: [{datetime: timestamp, sg: 123}], markers: [], lastSG: {sg: 123}, lastSGTrend: 'FLAT', sMedicalDeviceTime: timestamp, medicalDeviceBatteryLevelPercent: 80, reservoirRemainingUnits: 100, activeInsulin: {amount: 1.2}};
+  const data = {lastMedicalDeviceDataUpdateServerTime: Date.parse(timestamp), medicalDeviceFamily: 'MINIMED', private: secret, sgs: [{datetime: timestamp, sg: 123}], markers: [], lastSG: {sg: 123}, lastSGTrend: 'FLAT', sMedicalDeviceTime: timestamp, medicalDeviceBatteryLevelPercent: 80, reservoirRemainingUnits: 100, activeInsulin: {amount: 1.2}};
   const output = source.transformPayload(data, {});
   assert.equal(output.entries[0].sgv, 123);
   assert.equal(output.devicestatus[0].pump.reservoir, 100);


### PR DESCRIPTION
MiniMed CareLink transformation can discard the newest valid glucose reading when lastSG differs or is missing. Device status uses fetch time instead of measurement time, allowing stale pump data to appear current and repeated polls to append duplicate status. UTC conduit timestamps also generate an invalid offset.

Preserve valid latest readings while applying trend only when lastSG matches; exclude zero/non-sensor rows. Use valid measurement timestamps for device status, omit invalid/already-stored status, preserve the legacy nested pump IOB and uploader battery fields, and fix UTC offsets without mutating reusable payloads. Keep the existing top-level pump.bolusiob alias for compatibility.

Seven new regression cases fail against the previous provider. All 78 upstream tests pass on Node 22.23.2 and 24.20.0 after the fix. Owned fixtures cover patient/pump and Guardian outputs, cutover timestamps, input reuse and missing metadata. This is bounded regression evidence, not live CareLink validation.

Stacked on the fix/dexcom-safe-logging branch in PR #64, including its internal-output logging fix; the diff against that branch contains the data-contract changes. Intended to unblock Nightscout 15.0.9's authorized mmconnect retirement (cgm-remote-monitor#8682). Transport and real vendor/hosting validation remain separate gates.
