### PR TITLE
Release connector listeners and settle output waits on stop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Connector regression tests
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['22.23.2', '24.20.0']
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install --ignore-scripts --no-audit --no-fund
+      - run: npm test

--- a/index.js
+++ b/index.js
@@ -33,16 +33,6 @@ function manage (env, ctx) {
 
   spec.kind = env.extendedSettings.connect.source;
 
-  var internal = { name: 'internal' };
-  var output = outputs(internal)(internal, ctx);
-  console.log("CONFIGURED OUTPUT", output);
-
-  // var things = internalLoop(input, output);
-  // everything known for output
-  // output must be passed into builder, before generate_driver is
-  // called.
-  var make = builder({ output });
-
   // select an available input source implementation based on env
   // variables/config
   var driver = sources(spec);
@@ -57,27 +47,39 @@ function manage (env, ctx) {
     console.log("Invalid configuration, disabling nightscout-connect");
     return;
   }
-  var impl = driver(validated.config, axios);
-  impl.generate_driver(make);
-  var things = make( );
-
-  function handle ( ) { return actor; };
+  var internal = { name: 'internal' };
+  var output = outputs(internal)(internal, ctx);
+  var actor;
+  var stopped = false;
+  function handle () { return actor; }
   handle.run = () => {
-    actor.send({type: 'START'});
+    if (!stopped) actor.send({type: 'START'});
     return Promise.resolve(handle);
-  }
+  };
   handle.stop = () => {
-    actor.stop( );
+    if (!stopped) {
+      stopped = true;
+      ctx.bus.removeListener('data-processed', handle.run);
+      ctx.bus.removeListener('tearDown', handle.stop);
+      ctx.bus.removeListener('teardown', handle.stop);
+      try { if (actor) actor.stop(); }
+      finally { output.close(); }
+    }
     return Promise.resolve(handle);
+  };
+  try {
+    var make = builder({output});
+    var impl = driver(validated.config, axios);
+    impl.generate_driver(make);
+    actor = interpret(make());
+    ctx.bus.once('data-processed', handle.run);
+    ctx.bus.once('tearDown', handle.stop);
+    ctx.bus.once('teardown', handle.stop);
+    actor.start();
+  } catch (error) {
+    handle.stop();
+    throw error;
   }
-
-
-  ctx.bus.once('data-processed', handle.run);
-  ctx.bus.once('tearDown', handle.stop);
-  // console.log(things);
-  var actor = interpret(things);
-  actor.start( );
-  // actor.send({type: 'START'});
 
   return handle;
 }

--- a/lib/outputs/internal.js
+++ b/lib/outputs/internal.js
@@ -1,149 +1,107 @@
-
-
 function persistent (config, ctx) {
-
   var known = null;
-  ctx.bus.on('data-processed', function (sbx) {
-    if (sbx.data.sgvs.length == 0) {
-      return;
-    }
+  var closed = false;
+  var pending = new Set();
 
-    function mills_or(thing, other) {
+  function updateKnown (sbx) {
+    if (closed || sbx.data.sgvs.length == 0) return;
+    function mills_or (thing, other) {
       var entry = sbx.lastEntry(thing);
-      return entry
-        ? entry.mills
-        : other
-        ;
+      return entry ? entry.mills : other;
     }
-
-    var last = {
+    known = {
       entries: new Date(mills_or(sbx.data.sgvs, 0)),
       sgvs: sbx.lastEntry(sbx.data.sgvs),
       treatments: new Date(mills_or(sbx.data.treatments, 0)),
       devicestatus: new Date(mills_or(sbx.data.devicestatus, 0)),
       profile: sbx.lastEntry(sbx.data.profile)
-
     };
-
-    known = last;
     console.log('Connect internal output: data processed');
-  });
+  }
+  ctx.bus.on('data-processed', updateKnown);
 
   function record_collection (kind, candidates) {
-    if (!candidates.length) {
-      return Promise.resolve( );
-    }
-
-    function record (resolve, reject) {
-
-      ctx[kind].create(candidates, (err, stored) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(stored);
+    if (closed || !candidates.length) return Promise.resolve();
+    return new Promise(function (resolve, reject) {
+      ctx[kind].create(candidates, function (err, stored) {
+        if (err) return reject(err);
+        resolve(stored);
       });
-    }
-
-    return new Promise(record);
-  }
-  function record_treatments (candidates) {
-    if (!candidates.length) {
-      return Promise.resolve( );
-    }
-    function record (resolve, reject) {
-
-      ctx.treatments.create(candidates, (err, stored) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(stored);
-      });
-    }
-
-    return new Promise(record);
+    });
   }
 
-  function record_entries (candidates) {
-    if (!candidates.length) {
-      return Promise.resolve( );
-    }
-    function record (resolve, reject) {
-
-      ctx.entries.create(candidates, (err, stored) => {
-        if (err) {
-          return reject(err);
-        }
-        return resolve(stored);
-      });
-    }
-
-    return new Promise(record);
+  function waitForProcessed () {
+    var cancel;
+    var promise = new Promise(function (resolve) {
+      function then () {
+        ctx.bus.removeListener('data-processed', then);
+        pending.delete(cancel);
+        resolve(closed ? null : known);
+      }
+      cancel = function () {
+        ctx.bus.removeListener('data-processed', then);
+        pending.delete(cancel);
+        resolve(null);
+      };
+      pending.add(cancel);
+      ctx.bus.once('data-processed', then);
+    });
+    return {promise: promise, cancel: cancel};
   }
 
   function persists (batch) {
+    if (closed) return Promise.resolve(null);
     console.log('Connect internal output: persisting batch');
-    var { entries, treatments, profiles, devicestatus } = batch;
-    entries = entries || [ ];
-    treatments = treatments || [ ];
-    profiles = profiles || [ ];
-    devicestatus = devicestatus || [ ];
-    /*
-    if (!batch.entries.length) {
+    var {entries, treatments, profiles, devicestatus} = batch;
+    entries = entries || [];
+    treatments = treatments || [];
+    profiles = profiles || [];
+    devicestatus = devicestatus || [];
+    if (!entries.length && !treatments.length && !profiles.length && !devicestatus.length) {
       return Promise.resolve(known);
     }
-    */
-    function processed (resolve, reject) {
-      if (entries.length == 0 && treatments.length == 0 && profiles.length == 0 && devicestatus.length == 0) {
-        // nothing to update, there may not be a signal for a long time.
-        return resolve(known);
-      }
-      function then ( ) {
-        resolve(known);
-      }
-      ctx.bus.once('data-processed', then);
-    }
-
-    var recorded = new Promise(processed);
-
-    return Promise.all([
-      record_entries(entries),
-      record_treatments(treatments),
+    var processed = waitForProcessed();
+    var cancel;
+    var stopped = new Promise(function (resolve) {
+      cancel = function () {resolve(null);};
+      pending.add(cancel);
+    });
+    var recorded = Promise.all([
+      record_collection('entries', entries),
+      record_collection('treatments', treatments),
       record_collection('devicestatus', devicestatus),
       record_collection('profile', profiles),
-      recorded]).then(function (settled) {
+      processed.promise
+    ]).then(function () {
       console.log('Connect internal output: batch settled');
-      return known;
-
-    }).catch(( ) => {
+      return closed ? null : known;
+    }).catch(function () {
       console.log('Connect internal output: persistence failed');
-      return known;
+      return closed ? null : known;
     });
-
-    return Promise.resolve(batch);
-
+    // Storage operations already issued cannot be cancelled here. Settle the
+    // output wait on stop and ignore late results without retaining bookmarks.
+    return Promise.race([recorded, stopped]).finally(function () {
+      processed.cancel();
+      pending.delete(cancel);
+    });
   }
-  persists.gap_for = function ( ) {
-    console.log("GAP FOR");
-    if (known) {
-      return Promise.resolve(known);
-    }
 
-    function wait (resolve, reject) {
-      ctx.bus.once('data-processed', then);
-      
-      function then ( ) {
-        console.log('Connect internal output: bookmark available');
-        return resolve(known);
-      }
+  persists.gap_for = function () {
+    if (closed) return Promise.resolve(null);
+    if (known) return Promise.resolve(known);
+    return waitForProcessed().promise;
+  };
 
-    }
-    console.log("WAITING FOR data-processed");
-    return new Promise(wait);
-
-  }
+  persists.close = function () {
+    if (closed) return;
+    closed = true;
+    known = null;
+    ctx.bus.removeListener('data-processed', updateKnown);
+    Array.from(pending).forEach(function (cancel) {cancel();});
+    pending.clear();
+  };
 
   return persists;
-
 }
-
 module.exports = persistent;

--- a/test/stop-cleanup.test.js
+++ b/test/stop-cleanup.test.js
@@ -1,0 +1,116 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {EventEmitter} = require('node:events');
+const fs = require('node:fs');
+const vm = require('node:vm');
+const path = require('node:path');
+const {createRequire} = require('node:module');
+const internal = require('../lib/outputs/internal');
+
+function context() {
+  return {bus: new EventEmitter(), bootErrors: [], entries: {create(rows, callback) {callback(null, rows);}},
+    treatments: {create(rows, callback) {callback(null, rows);}}, profile: {create(rows, callback) {callback(null, rows);}},
+    devicestatus: {create(rows, callback) {callback(null, rows);}}};
+}
+function processed(ctx) {
+  const data = {sgvs: [{mills: 1}], treatments: [], devicestatus: [], profile: []};
+  ctx.bus.emit('data-processed', {data, lastEntry: rows => rows.at(-1)});
+}
+function wrapper({valid = true, generateError = false} = {}) {
+  const filename = path.resolve(__dirname, '../index.js'), localRequire = createRequire(filename);
+  const state = {starts: 0, stops: 0, sends: 0};
+  const actor = {start() {state.starts++;}, stop() {state.stops++;}, send() {state.sends++;}};
+  const driver = () => ({generate_driver() {if (generateError) throw new Error('fixture setup failed');}});
+  driver.validate = () => ({ok: valid, config: {}, errors: valid ? [] : ['fixture invalid']});
+  const sandbox = {module: {exports: {}}, console: {log() {}}, require(name) {
+    if (name === 'xstate') return {interpret: () => actor};
+    if (name === './lib/sources') return () => driver;
+    if (name === './lib/builder') return () => () => ({});
+    return localRequire(name);
+  }};
+  vm.runInNewContext(fs.readFileSync(filename, 'utf8'), sandbox, {filename});
+  return {manage: sandbox.module.exports, state};
+}
+const env = {extendedSettings: {connect: {source: 'fixture'}}};
+
+test('output close removes permanent/bookmark listeners and settles bookmark waits', async () => {
+  const ctx = context(), output = internal({}, ctx), waiting = output.gap_for();
+  assert.equal(typeof output.close, 'function');
+  output.close(); output.close();
+  assert.equal(ctx.bus.listenerCount('data-processed'), 0);
+  assert.equal(await waiting, null);
+  assert.equal(await output.gap_for(), null);
+});
+
+test('output close settles pending storage waits without accepting later data', async () => {
+  const ctx = context(); let complete;
+  ctx.entries.create = (rows, callback) => {complete = callback;};
+  const output = internal({}, ctx), waiting = output({entries: [{sgv: 100}]});
+  assert.equal(typeof output.close, 'function');
+  output.close();
+  assert.equal(await waiting, null);
+  processed(ctx); complete(null, []);
+  assert.equal(await output({entries: [{sgv: 120}]}), null);
+  assert.equal(ctx.bus.listenerCount('data-processed'), 0);
+});
+
+test('failed storage removes its data-processed waiter without needing another event', async () => {
+  const ctx = context(); ctx.entries.create = (rows, callback) => callback(new Error('fixture failure'));
+  const output = internal({}, ctx);
+  assert.equal(await output({entries: [{sgv: 100}]}), null);
+  assert.equal(ctx.bus.listenerCount('data-processed'), 1);
+  if (output.close) output.close();
+});
+
+test('successful output remains usable over two processing cycles', async () => {
+  const ctx = context(), output = internal({}, ctx);
+  for (let cycle = 0; cycle < 2; cycle++) {
+    const result = output({entries: [{sgv: 100}]}); processed(ctx);
+    assert.equal((await result).entries.getTime(), 1);
+    assert.equal(ctx.bus.listenerCount('data-processed'), 1);
+  }
+  if (output.close) output.close();
+});
+
+test('null collection fields still represent an empty batch', async () => {
+  const ctx = context(), output = internal({}, ctx);
+  assert.equal(await output({entries: null, treatments: null, profiles: null, devicestatus: null}), null);
+  assert.equal(ctx.bus.listenerCount('data-processed'), 1);
+  if (output.close) output.close();
+});
+
+test('wrapper stop detaches all owned listeners over two cycles and prevents later starts', async () => {
+  const ctx = context(), {manage, state} = wrapper();
+  for (let cycle = 0; cycle < 2; cycle++) {
+    const handle = manage(env, ctx);
+    await handle.stop(); await handle.stop();
+    await handle.run(); processed(ctx);
+    assert.equal(ctx.bus.listenerCount('data-processed'), 0);
+    assert.equal(ctx.bus.listenerCount('tearDown'), 0);
+    assert.equal(ctx.bus.listenerCount('teardown'), 0);
+    assert.equal(state.stops, cycle + 1);
+    assert.equal(state.sends, 0);
+  }
+});
+
+test('wrapper responds to both teardown spellings exactly once', async () => {
+  for (const event of ['teardown', 'tearDown']) {
+    const ctx = context(), {manage, state} = wrapper();
+    manage(env, ctx); ctx.bus.emit(event); ctx.bus.emit(event);
+    assert.equal(state.stops, 1);
+    assert.equal(ctx.bus.listenerCount('data-processed'), 0);
+  }
+});
+
+test('invalid configuration allocates no output listeners', () => {
+  const ctx = context(), {manage, state} = wrapper({valid: false});
+  assert.equal(manage(env, ctx), undefined);
+  assert.equal(ctx.bus.listenerCount('data-processed'), 0);
+  assert.equal(state.starts, 0);
+});
+
+test('driver setup failure closes the allocated output', () => {
+  const ctx = context(), {manage} = wrapper({generateError: true});
+  assert.throws(() => manage(env, ctx), /fixture setup failed/);
+  assert.equal(ctx.bus.listenerCount('data-processed'), 0);
+});


### PR DESCRIPTION
Stopping the actor leaves the connector wrapper and internal output subscribed to the Nightscout bus. Pending bookmark/storage waits can remain unresolved, failed writes leave an event waiter, and invalid configuration or driver setup failures can retain an output listener.

Add idempotent wrapper/output shutdown, accept both teardown event spellings, remove owned listeners, clear the bookmark, settle pending output waits and ignore late results. Validate source configuration before allocating the output and clean up when setup throws. Already-issued storage writes are not cancelled or rolled back; shutdown settles the connector's wait and prevents further output work.

Seven new regression cases fail on parent a519633 (the same source tree as Nightscout's c962a13 pin). Nine new cases now cover those defects plus successful repeated writes and null/empty batches. All 87 tests pass on actual Node 22.23.2 and 24.20.0. Add upstream CI on those floors; Nightscout will also validate the published package through its real connector and server tests.

Stacked on #64, which already contains merged #65. This completes the remaining connector lifecycle work for nightscout/cgm-remote-monitor#8605 without changing provider transformations or configuration. No real vendor account is used. Rollback reverts this commit and its Nightscout pin together.
