### PR TITLE
Make connector debug logging opt-in (#8714)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ point.
 * `ENABLE=connect` include the keyword `connect` in the `ENABLE` list.
 * Environment variable prefix `CONNECT_`:
   * `CONNECT_SOURCE` - The name for the source of one of the supported inputs.  one of `nightscout`, `dexcomshare`, etc...
+  * `CONNECT_DEBUG` - Opt in to routine connector diagnostics with `true` or
+    `on`. By default, the Nightscout plugin inherits `env.debug.logging`
+    (`DEBUG_LOGGING` in supporting Nightscout versions), or stays quiet when
+    that setting is absent. An explicit `false` or `off` overrides server
+    debugging. Restart Nightscout after changing the environment setting.
+
+The embedded plugin logs warnings and failures regardless of debugging. Debug
+output contains operation summaries; authentication/session objects, patient
+records, HTTP response bodies and XState context are not dumped. HTTP failures
+retain numeric status codes. Each connector has its own logger; the global
+console is unchanged. CLI output targets and explicit HAR capture are separate
+from this embedded-plugin logging setting.
 
 ## Testing
 

--- a/index.js
+++ b/index.js
@@ -11,37 +11,41 @@ var axios = require('axios');
 var builder = require('./lib/builder');
 var sources = require('./lib/sources');
 var outputs = require('./lib/outputs');
+var createLogger = require('./lib/logging');
 
 
 function internalLoop (input, output) {
 }
 
 function manage (env, ctx) {
+  var connect = env.extendedSettings.connect;
+  var log = createLogger(connect && connect.debug !== undefined
+    ? connect.debug : env.debug && env.debug.logging);
 
   // source
   // output
   // env.extendedSettings.connect.source
   var spec = { kind: 'disabled' };
   if (!env.extendedSettings.connect) {
-    console.log("Skipping disabled nightscout-connect");
+    log.debug('Skipping disabled connector');
     return;
   }
   if (!env.extendedSettings.connect.source) {
-    console.log("Skipping disabled nightscout-connect, no source driver spec");
+    log.debug('Skipping connector without a source');
     return;
   }
 
   spec.kind = env.extendedSettings.connect.source;
 
-  var internal = { name: 'internal' };
+  var internal = { name: 'internal', logger: log };
   var output = outputs(internal)(internal, ctx);
-  console.log("CONFIGURED OUTPUT", output);
+  log.debug('Internal output configured');
 
   // var things = internalLoop(input, output);
   // everything known for output
   // output must be passed into builder, before generate_driver is
   // called.
-  var make = builder({ output });
+  var make = builder({ output, logger: log });
 
   // select an available input source implementation based on env
   // variables/config
@@ -51,13 +55,13 @@ function manage (env, ctx) {
       ctx.bootErrors.push(...validated.errors);
   }
 
-  console.log("INPUT PARAMS", spec, validated.config);
+  log.debug('Input configured');
 
   if (!validated.ok) {
-    console.log("Invalid, disabling nightscout-connect", validated);
+    log.error('Invalid configuration, disabling connector');
     return;
   }
-  var impl = driver(validated.config, axios);
+  var impl = driver(validated.config, axios, log);
   impl.generate_driver(make);
   var things = make( );
 
@@ -72,7 +76,6 @@ function manage (env, ctx) {
   }
 
 
-  ctx.bus.on('tick', console.log.bind(console, 'DEBUG nightscout-connect'));
   ctx.bus.once('data-processed', handle.run);
   ctx.bus.once('tearDown', handle.stop);
   // console.log(things);

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -33,11 +33,11 @@ function builder (config) {
   }
 
   function make ( ) {
-    var sessionMachine = createSession(impl);
+    var sessionMachine = createSession(impl, { logger: config.logger });
     // var outputMachine = createOutput(output);
     // if (output.gaps_for) { }
 
-    var pollingMachine = createPoller(sessionMachine, consumer);
+    var pollingMachine = createPoller(sessionMachine, consumer, { logger: config.logger });
     return pollingMachine;
 
   }
@@ -52,6 +52,7 @@ function builder (config) {
     // cfg.frame.maxRetries
     //
     var fetchConfig = {
+      logger: config.logger,
       maxRetries: cfg.frame.maxRetries,
       frame_retry_duration: backoff(cfg.frame.backoff)
     };
@@ -67,6 +68,7 @@ function builder (config) {
 
     var capture = config.capture && cfg.tracker ? { start: cfg.tracker, ...config.capture } : null;
     var cycleConfig = {
+      logger: config.logger,
       delay_per_frame_error: backoff(cfg.backoff),
       expected_data_interval_ms: cfg.expected_data_interval_ms,
       name,

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,0 +1,26 @@
+'use strict';
+
+function enabled (value) {
+  return value === true || (typeof value === 'string' && /^(true|on)$/i.test(value.trim()));
+}
+
+// Each connector owns its logger. Never replace the process-wide console or
+// print source credentials, patient payloads, HTTP bodies or XState context.
+function createLogger (debug) {
+  const verbose = enabled(debug);
+  function diagnostic (level, message, error) {
+    const status = error && error.response && error.response.status;
+    const suffix = Number.isInteger(status) && status >= 100 && status <= 599
+      ? ' (HTTP ' + status + ')' : '';
+    console[level]('nightscout-connect: ' + message + suffix);
+  }
+  return {
+    debug (message) {
+      if (verbose) console.debug('DEBUG nightscout-connect: ' + message);
+    },
+    warn (message) { diagnostic('warn', message); },
+    error (message, error) { diagnostic('error', message, error); }
+  };
+}
+
+module.exports = createLogger;

--- a/lib/machines/cycle.js
+++ b/lib/machines/cycle.js
@@ -1,7 +1,9 @@
+var createLogger = require('../logging');
 const { createMachine, Machine, actions, interpret, spawn  } = require('xstate');
 var { increment_field } = require('./utils');
 
 function createCycleMachine (services, config) {
+  var log = config && config.logger || createLogger(false);
   var { capture } = config;
   var frameName = ['frame', config.name || ''].join('');
   const loopConfig = {
@@ -9,23 +11,24 @@ function createCycleMachine (services, config) {
       fetchService: services.fetchMachine,
     },
     actions: {
+      // Capture is optional. Explicit no-ops avoid warnings on every cycle.
       resetCapture: capture
         ?
           ({tracker, runs, ...ctx}, event) => {
             tracker.reset( );
           }
-        : null,
+        : () => {},
       startCapture: capture
         ?
           actions.assign({
             tracker: (context, event) => capture.start( )
           })
-        : null,
+        : () => {},
       recordFrame: capture ? actions.pure(({ tracker, runs, ...ctx }, event) => {
         var fs = require('fs');
         var harOutput = tracker.getGeneratedHar( );
         fs.writeFileSync(`${capture.dir}/${frameName}-${runs}.har`, JSON.stringify(harOutput), 'utf-8');
-      }) : null,
+      }) : () => {},
     },
     guards: {
     },
@@ -134,7 +137,7 @@ function createCycleMachine (services, config) {
       },
       Operating: {
         entry: [
-          actions.log('Operating Invoking'),
+          () => log.debug('Polling cycle started'),
         ],
         on: {
           FETCH_DATA: {
@@ -191,7 +194,7 @@ function createCycleMachine (services, config) {
       After: {
         entry: [
           increment_field('runs'),
-          actions.log('AFTER'),
+          () => log.debug('Polling cycle scheduled'),
           'recordFrame',
           'resetCapture',
         ],

--- a/lib/machines/fetch.js
+++ b/lib/machines/fetch.js
@@ -1,7 +1,9 @@
+var createLogger = require('../logging');
 const { createMachine, Machine, actions, interpret, spawn  } = require('xstate');
 var { increment_field } = require('./utils');
 
 function createFetchMachine (impl, config) {
+  var log = config && config.logger || createLogger(false);
   var adapter = {
     dataFetchService (context, event) {
       // console.log('MAYBE FETCH', context, event);
@@ -207,7 +209,7 @@ function createFetchMachine (impl, config) {
                 type: 'DATA_RECEIVED',
                 data: event.data
               })),
-              actions.log('FETCHING')
+              () => log.debug('Data fetched')
             ]
           },
           onError: {
@@ -240,7 +242,7 @@ function createFetchMachine (impl, config) {
                 type: 'TRANSFORMED_DATA',
                 data: event.data
               })),
-              actions.log()
+              () => log.debug('Data transformed')
             ]
           },
           onError: {
@@ -309,15 +311,13 @@ function createFetchMachine (impl, config) {
       Success: {
         entry: [
           actions.sendParent({type: "FRAME_SUCCESS"}),
-          actions.log("FRAME DONE"),
-          actions.log( ),
+          () => log.debug('Data persisted'),
         ],
         always: { target: 'Done' }
       },
       Error: {
         entry: [
-          actions.log("FRAME ERROR"),
-          actions.log( ),
+          (context, event) => log.error('Polling frame failed', event.data),
           actions.sendParent({type: "FRAME_ERROR"}),
         ],
         always: [

--- a/lib/machines/poller.js
+++ b/lib/machines/poller.js
@@ -1,8 +1,10 @@
+var createLogger = require('../logging');
 const { createMachine, Machine, actions, interpret, spawn  } = require('xstate');
 var { increment_field } = require('./utils');
 
 // TOOD: reconsider naming Bus.
 function createPollingMachine (sessionService, consumer, config) {
+  var log = config && config.logger || createLogger(false);
   /*
   consumer.{services,names,states}
   */
@@ -69,26 +71,26 @@ function createPollingMachine (sessionService, consumer, config) {
           // '': { target: '.Ready' },
           DEBUG: {
             actions: [
-              actions.log(),
+              () => log.debug('Poller debug'),
             ]
           },
       // should session track it's own telemetry
       AUTHENTICATION_ERROR: {
         actions: [
           increment_field('authentication_errors'),
-          actions.log(),
+          (context, event) => log.error('Authentication failed', event.data),
         ]
       },
       AUTHORIZATION_ERROR: {
         actions: [
           increment_field('authorization_errors'),
-          actions.log(),
+          (context, event) => log.error('Authorization failed', event.data),
         ]
       },
       AUTHENTICATED: {
         actions: [
           increment_field('authentications'),
-          actions.log(),
+          () => log.debug('Authenticated'),
         ]
       },
           SESSION_REQUIRED: {
@@ -125,7 +127,7 @@ function createPollingMachine (sessionService, consumer, config) {
             ],
           },
           FRAME_DONE: {
-            actions: [actions.log(),
+            actions: [() => log.debug('Polling frame completed'),
               actions.send("STEP"),
             ],
           },

--- a/lib/machines/session.js
+++ b/lib/machines/session.js
@@ -1,8 +1,10 @@
+var createLogger = require('../logging');
 
 const { createMachine, Machine, actions, interpret, spawn  } = require('xstate');
 var { increment_field } = require('./utils');
 
 function createSessionMachine(impl, config) {
+  var log = config && config.logger || createLogger(false);
   var adapter = {
     maybeAuthenticate (context, event) {
       // TODO: get credentials
@@ -52,7 +54,7 @@ function createSessionMachine(impl, config) {
     on: {
       DEBUG: {
         actions: [
-          actions.log()
+          () => log.debug('Session debug')
         ]
       },
       // TODO: rename SET_SESSION?

--- a/lib/outputs/index.js
+++ b/lib/outputs/index.js
@@ -11,7 +11,6 @@ function select (config) {
   var defaults = { name: 'default' };
   config = { ...config, ...defaults, ...config };
   var { name } = config;
-  console.log("SELECTING OUTPUT", config, name, outputs[name] || outputs.default);
   return outputs[name] || outputs.default;
 }
 module.exports = select;

--- a/lib/outputs/internal.js
+++ b/lib/outputs/internal.js
@@ -1,6 +1,8 @@
+var createLogger = require('../logging');
 
 
 function persistent (config, ctx) {
+  var log = config.logger || createLogger(config.debug);
 
   var known = null;
   ctx.bus.on('data-processed', function (sbx) {
@@ -26,11 +28,7 @@ function persistent (config, ctx) {
     };
 
     known = last;
-    console.log("DEBUG nightscout-connect", 'data-loaded',
-      // Object.keys(sbx.data),
-      last
-    
-    );
+    log.debug("data-loaded");
   });
 
   function record_collection (kind, candidates) {
@@ -85,7 +83,7 @@ function persistent (config, ctx) {
   }
 
   function persists (batch) {
-    console.log("INTERNAL PERSISTENCE", batch);
+    log.debug("Internal persistence started");
     var { entries, treatments, profiles, devicestatus } = batch;
     entries = entries || [ ];
     treatments = treatments || [ ];
@@ -114,12 +112,12 @@ function persistent (config, ctx) {
       record_treatments(treatments),
       record_collection('devicestatus', devicestatus),
       record_collection('profile', profiles),
-      recorded]).then(function (settled) {
-      console.log("ALL SETTLED INTERNAL PERSIST", settled, arguments);
+      recorded]).then(function () {
+      log.debug("Internal persistence completed");
       return known;
 
-    }).catch(( ) => {
-      console.log("PERSISTED INTERNAL ERRORED", arguments);
+    }).catch((error) => {
+      log.error("Internal persistence failed", error);
       return known;
     });
 
@@ -127,7 +125,7 @@ function persistent (config, ctx) {
 
   }
   persists.gap_for = function ( ) {
-    console.log("GAP FOR");
+    log.debug("Checking data bookmark");
     if (known) {
       return Promise.resolve(known);
     }
@@ -136,12 +134,12 @@ function persistent (config, ctx) {
       ctx.bus.once('data-processed', then);
       
       function then ( ) {
-        console.log("EVENTUALLY FOUND", known);
+        log.debug("Data bookmark available");
         return resolve(known);
       }
 
     }
-    console.log("WAITING FOR data-processed");
+    log.debug("Waiting for processed data");
     return new Promise(wait);
 
   }

--- a/lib/sources/dexcomshare.js
+++ b/lib/sources/dexcomshare.js
@@ -1,3 +1,4 @@
+var createLogger = require('../logging');
 
 var qs = require('qs');
 var url = require('url');
@@ -127,7 +128,8 @@ function trendToDirection (trend) {
 }
 
 
-function dexcomshareSource (opts, axios) {
+function dexcomshareSource (opts, axios, log) {
+  log = log || createLogger(opts.debug);
 
   var baseURL = base_for(opts);
   var default_headers = { 'Content-Type': modDefaults.mime,
@@ -156,9 +158,7 @@ function dexcomshareSource (opts, axios) {
         return data;
       })
       .catch((err) => {
-        var status = err && err.response && err.response.status;
-        var data = err && err.response && err.response.data;
-        console.log("ERROR AUTHENTICATING ACCOUNT", "status=" + status, "data=", data, "message=", err && err.message);
+        log.error("Dexcom authentication failed", err);
         // Propagate the failure as a rejection so the state machine treats it as a
         // real failure rather than silently passing an Error object downstream where
         // it gets serialized into the next request body.
@@ -182,9 +182,7 @@ function dexcomshareSource (opts, axios) {
         return response.data;
       })
       .catch((err) => {
-        var status = err && err.response && err.response.status;
-        var data = err && err.response && err.response.data;
-        console.log("FAILED TO GET DEXCOM SHARE SESSION", "status=" + status, "data=", data, "message=", err && err.message);
+        log.error("Dexcom session request failed", err);
         return Promise.reject(err);
       });
     },
@@ -205,9 +203,7 @@ function dexcomshareSource (opts, axios) {
         return response.data;
       })
       .catch((err) => {
-        var status = err && err.response && err.response.status;
-        var data = err && err.response && err.response.data;
-        console.log("FAILED TO GET DEXCOM SHARE LATEST GLUCOSE", "status=" + status, "data=", data, "message=", err && err.message);
+        log.error("Dexcom glucose request failed", err);
         return Promise.reject(err);
       });
     },
@@ -221,7 +217,7 @@ function dexcomshareSource (opts, axios) {
       return { entries: data.map(dex_to_entry) };
     },
     align_to_glucose (last_known) {
-      console.log("INSIDE DEXCOM SOURCE DRIVER ALIGNMENT FOR GLUCOSE");
+      log.debug("Aligning Dexcom polling schedule");
       if (!last_known || !last_known.entries) {
         return;
       }
@@ -229,7 +225,7 @@ function dexcomshareSource (opts, axios) {
       var last_glucose_at = last_known.entries;
       var missing = ((new Date( )).getTime( ) - last_glucose_at.getTime( )) / (1000 * 60 * 5)
       if (missing > 1 && missing < 3) {
-        console.log("READJUSTING SHOULD MAKE A DIFFERENCE MISSING", missing);
+        log.debug("Dexcom polling schedule adjusted");
 
       }
       var next_due = last_glucose_at.getTime( ) + (Math.ceil(missing) * 1000 * 60 * 5);

--- a/lib/sources/glooko/convert.js
+++ b/lib/sources/glooko/convert.js
@@ -171,7 +171,6 @@ function generate_nightscout_treatments(batch, timestampDelta) {
     })
   }
 
-  console.log('GLOOKO data transformation complete, returning', treatments.length, 'treatments');
 
   return treatments;
 }

--- a/lib/sources/glooko/index.js
+++ b/lib/sources/glooko/index.js
@@ -1,3 +1,4 @@
+var createLogger = require('../../logging');
 /*
 *
 * https://github.com/jonfawcett/glooko2nightscout-bridge/blob/master/index.js#L146
@@ -237,7 +238,8 @@ function constructV3GraphUrl (patientCode, startDate, endDate) {
     + '&' + seriesParams
     + '&locale=en&insulinTooltips=false&filterBgReadings=false&splitByDay=false';
 }
-function glookoSource (opts, axios) {
+function glookoSource (opts, axios, log) {
+  log = log || createLogger(opts.debug);
   var webOrigin = opts.glookoWebOrigin || web_origin_for(opts);
   var default_headers = { 'Content-Type': Defaults.mime,
                           'Accept': 'application/json, text/plain, */*',
@@ -257,7 +259,7 @@ function glookoSource (opts, axios) {
       function apiLogin ( ) {
       var payload = login_payload(opts);
       return http.post(Defaults.login, payload).then((response) => {
-        console.log("GLOOKO AUTH", response.headers, response.data);
+        log.debug("Glooko authentication completed");
           assertNoTwoFactorRequired(response.data);
           return { cookies: extractSetCookie(response.headers), user: response.data };
       });
@@ -322,7 +324,7 @@ function glookoSource (opts, axios) {
         headers["Sec-Fetch-Dest"] = "empty";
         headers["Sec-Fetch-Mode"] = "cors";
         headers["Sec-Fetch-Site"] = "same-site";
-        console.log('GLOOKO FETCHER LOADING', endpoint);
+        log.debug("Glooko data requested");
         return http.get(endpoint, { headers, params })
           .then((resp) => resp.data);
       }
@@ -410,14 +412,14 @@ function glookoSource (opts, axios) {
                   .then((v3Graph) => ({ ...withProfile, v3Graph }));
               })
               .catch((err) => {
-                console.log('GLOOKO V3 PROFILE/GRAPH FETCH FAILED', err && err.message);
+                log.error("Glooko v3 profile or graph fetch failed", err);
                 return some;
               });
           }
           return fetcher(constructV3GraphUrl(patientCode, new Date(two_days_ago), new Date( )))
             .then((v3Graph) => ({ ...some, v3Graph }))
             .catch((err) => {
-              console.log('GLOOKO V3 GRAPH FETCH FAILED', err && err.message);
+              log.error("Glooko v3 graph fetch failed", err);
               return some;
             });
         });
@@ -427,7 +429,7 @@ function glookoSource (opts, axios) {
     },
     transformData (batch) {
       // TODO
-      console.log('GLOOKO passing batch for transforming');
+      log.debug("Glooko data transformation started");
       //console.log("TODO TRANSFORM", batch);
       var treatments = helper.generate_nightscout_treatments(batch, opts.glookoTimezoneOffset);
       var entries = generate_nightscout_entries(batch && batch.readings, opts.glookoTimezoneOffset);
@@ -487,7 +489,6 @@ glookoSource.validate = function validate_inputs (input) {
   var baseURL = base_for(input);
 
   const offset = !isNaN(input.glookoTimezoneOffset) ? input.glookoTimezoneOffset * -60 * 60 * 1000 : 0
-  console.log('GLOOKO using ms offset:', offset, input.glookoTimezoneOffset);
 
   var config = {
     glookoEnv: input.glookoEnv,

--- a/lib/sources/index.js
+++ b/lib/sources/index.js
@@ -11,7 +11,6 @@ var sources = {
 function select (config) {
   var { kind } = config;
   var result = sources[kind] || sources.testImpl;
-  console.log("KIND", kind, result);
   return result;
 }
 select.kinds = sources;

--- a/lib/sources/librelinkup.js
+++ b/lib/sources/librelinkup.js
@@ -1,3 +1,4 @@
+var createLogger = require('../logging');
 
 var qs = require('qs');
 var url = require('url');
@@ -58,7 +59,8 @@ function base_for (spec) {
   };
   return url.format(base);
 }
-function linkUpSource (opts, axios) {
+function linkUpSource (opts, axios, log) {
+  log = log || createLogger(opts.debug);
   var default_headers = { 'Content-Type': Defaults.mime,
                           'Accept': Defaults.mime,
                           'Accept-Encoding': "gzip, deflate, br",
@@ -75,7 +77,7 @@ function linkUpSource (opts, axios) {
         password: opts.linkUpPassword
       };
       return http.post(Defaults.Login, payload).then((response) => {
-        console.log("LIBRE LINKUP AUTH", response.headers, response.data);
+        log.debug("LibreLinkUp authentication completed");
         return response.data;
 
       });
@@ -89,12 +91,12 @@ function linkUpSource (opts, axios) {
         'Authorization': [ 'Bearer', token ].join(' ')
       };
       return http.get(Defaults.Connections, { headers }).then((resp) => {
-        console.log("CONNECTIONS RESPONSE FROM LIBRELINKUP", resp.status, resp.headers, resp.data);
+        log.debug("LibreLinkUp connections fetched");
         var connections = resp.data.data;
 
         if (connections.length == 0) {
           var err = new Error("NO CONNECTION WITH LIBRE LINKUP AVAILABLE");
-          console.log(err);
+          log.error("No LibreLinkUp connection available");
           throw err;
         }
         if (connections.length > 1 && opts.linkUpPatientId) {
@@ -104,11 +106,11 @@ function linkUpSource (opts, axios) {
           }
         }
         if (connections.length > 1) {
-          console.log("WARNING choose one of the", connections.length, 'patientIds and assign to CONNECT_LINK_UP_PATIENT_ID variable.')
+          log.warn("Multiple LibreLinkUp patients: set CONNECT_LINK_UP_PATIENT_ID to select a patient")
         }
         var result = connections[0];
         result.authTicket = auth.data.authTicket;
-        console.log("LIBRE SESSION FROM AUTH", result);
+        log.debug("LibreLinkUp session established");
         return result;
 
       });
@@ -127,7 +129,7 @@ function linkUpSource (opts, axios) {
         'Authorization': `Bearer ${token}`
       };
       return http.get(graph_url, { headers }).then((resp) => {
-        console.log("RECEIVED LIBRE GRAPH DATA", resp.status, resp.headers, resp.data);
+        log.debug("LibreLinkUp graph fetched");
         return resp.data;
       });
     },
@@ -160,11 +162,11 @@ function linkUpSource (opts, axios) {
       var treatments = [ ];
       var devicestatus = [ ];
       var profiles = [ ];
-      console.log("TRANSFORMING LIBRE BATCH", batch);
+      log.debug("LibreLinkUp data transformed");
       return { entries, treatments, devicestatus, profiles };
     },
     align_to_glucose (last_known) {
-      console.log("LIBRELINKUP SOURCE DRIVER ALIGNMENT FOR GLUCOSE");
+      log.debug("Aligning LibreLinkUp polling schedule");
       if (!last_known || !last_known.entries) {
         return;
       }
@@ -172,7 +174,7 @@ function linkUpSource (opts, axios) {
       var last_glucose_at = last_known.entries;
       var missing = ((new Date( )).getTime( ) - last_glucose_at.getTime( )) / (1000 * 60 * opts.linkUpInterval)
       if (missing > 1 && missing < 3) {
-        console.log("READJUSTING SHOULD MAKE A DIFFERENCE MISSING", missing);
+        log.debug("LibreLinkUp polling schedule adjusted");
 
       }
       var next_due = last_glucose_at.getTime( ) + (Math.ceil(missing) * 1000 * 60 * opts.linkUpInterval);

--- a/lib/sources/minimedcarelink/index.js
+++ b/lib/sources/minimedcarelink/index.js
@@ -1,3 +1,4 @@
+var createLogger = require('../../logging');
 
 var qs = require('qs');
 var url = require('url');
@@ -209,7 +210,8 @@ function deviceStatusEntry (data, deviceName) {
   return common
 }
 
-function carelinkSource (opts, axios) {
+function carelinkSource (opts, axios, log) {
+  log = log || createLogger(opts.debug);
 
   var baseURL = base_for(opts);
   var default_headers = { //  'Content-Type': modDefaults.mime,
@@ -242,9 +244,9 @@ function carelinkSource (opts, axios) {
         var headers = {
           ...html_headers
         };
-        console.log("AUTH WITH", modDefaults.login_url, params, headers);
+        log.debug("CareLink login started");
         return http.get(modDefaults.login_url, { params, headers }).then((resp) => {
-          console.log("FIRST STEP LOGIN FLOW", resp.headers, resp.data);
+          log.debug("CareLink login page received");
           var regex = /(<form action=")(.*)" method="POST"/gm;
           var endpoint = (regex.exec(resp.data) || [])[2] || '';
 
@@ -265,8 +267,7 @@ function carelinkSource (opts, axios) {
           // return resp.data;
 
         }).catch((error) => {
-          if (error.response)
-          console.log("ERROR", error.response.headers, error.response.data);
+          log.error("CareLink login page failed", error);
           return Promise.reject(error);
         });
       }
@@ -293,9 +294,9 @@ function carelinkSource (opts, axios) {
         // var loginEndpoint = url.parse(loginFlow.endpoint);
         // query = { ...qs.parse(loginEndpoint.query), ...query };
         // loginEndpoint = url.format({ ...loginEndpoint, search: null, query });
-        console.log("SUBMITTING LOGIN", loginEndpoint, payload, params, headers);
+        log.debug("CareLink login submitted");
         return http.post(loginEndpoint, qs.stringify(payload), { params, headers }).then((resp) => {
-          console.log("SUCCESS LOGGING IN", resp.headers, resp.data);
+          log.debug("CareLink login completed");
           var regex = /(<form action=")(.*)" method="POST"/gm;
           var endpoint = (regex.exec(resp.data) || [])[2] || '';
 
@@ -323,11 +324,7 @@ function carelinkSource (opts, axios) {
           return formInfo;
 
         }).catch((error) => {
-          if (error.response) {
-            console.log("ERROR SUBMITTING LOGIN FLOW", error.response.headers, error.response.data);
-          } else {
-            console.log('ERROR', error);
-          }
+          log.error("CareLink login failed", error);
           // return error;
           return Promise.reject(error);
           throw error;
@@ -343,17 +340,16 @@ function carelinkSource (opts, axios) {
           , ...html_headers
           // ,  'Cookie': flow.cookies.map((c) => { return  new tough.Cookie(c).cookieString( ); })
         };
-        console.log("SUBMITTING CONSENT FLOW", flow.endpoint, payload, params, headers);
+        log.debug("CareLink consent submitted");
         function validateStatus (status) {
           return status < 400 && status >= 200;
         }
 
         return http.post(flow.endpoint, qs.stringify(payload), { params, headers, validateStatus }).then((resp) => {
-          console.log("SUCCESS WITH CONSENT FOR", resp.headers, resp.data);
+          log.debug("CareLink consent completed");
           var cookies = jar.getCookiesSync(baseURL);
-          console.log("COOKIES", cookies);
-          var token = cookies.filter((c) => { console.log(c); return c.key == modDefaults.cookies.token; }).pop( ).value;
-          var expires = cookies.filter((c) => { console.log(c); return c.key == modDefaults.cookies.recency; }).pop( ).value;
+          var token = cookies.filter((c) => { return c.key == modDefaults.cookies.token; }).pop( ).value;
+          var expires = cookies.filter((c) => { return c.key == modDefaults.cookies.recency; }).pop( ).value;
           var flow = {
             location: resp.headers['location']
           , cookies
@@ -367,12 +363,7 @@ function carelinkSource (opts, axios) {
           return flow;
           // return resp.data;
         }).catch((error) => {
-          if (error.response) {
-            console.log("ERROR SUBMITTING CONSENT", error.response.headers, error.response.data);
-          }
-          else {
-            console.log("ERROR SUBMITTING CONSENT FLOW", error);
-          }
+          log.error("CareLink consent failed", error);
           return Promise.reject(error);
         });
       }
@@ -397,15 +388,12 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.me_url, { headers }).then((resp) => {
-          console.log("SUCCESS FETCHING USER", resp.headers, resp);
+          log.debug("CareLink user fetched");
           account.user = resp.data;
           return resp.data;
         return resp.data;
         }).catch((error) => {
-          console.log("ERROR FETCHING USER", error);
-          if (error.response) {
-            console.log("USER ERROR HEADERS/DATA", error.response.headers, error.response.data);
-          }
+          log.error("CareLink user fetch failed", error);
           return Promise.reject(error);
         });
       }
@@ -415,11 +403,11 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.my_profile_url, { headers }).then((resp) => {
-          console.log("GOT PROFILE", resp.headers, resp.data);
+          log.debug("CareLink profile fetched");
           account.profile = resp.data;
           return resp.data;
         }).catch((error) => {
-          console.log("ERROR FETCHING PROFILE", error);
+          log.error("CareLink profile fetch failed", error);
         });
       }
 
@@ -432,11 +420,11 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.country_settings_url, { params, headers }).then((resp) => {
-          console.log("GOT COUNTRY SETTINGS", resp.headers, resp.data);
+          log.debug("CareLink country settings fetched");
           account.requirements = resp.data;
           return resp.data;
         }).catch((error) => {
-          console.log("ERROR FETCHING COUNTRY SETTINGS", error);
+          log.error("CareLink country settings fetch failed", error);
           return Promise.reject(error);
         });
       }
@@ -446,11 +434,11 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.config_check_url, { headers }).then((resp) => {
-          console.log("GOT M2M SETTINGS", resp.headers, resp.data);
+          log.debug("CareLink sharing settings fetched");
           account.m2m_enabled = resp.data.value;
           return resp.data;
         }).catch((error) => {
-          console.log("ERROR FETCHING M2M SETTINGS", error);
+          log.error("CareLink sharing settings fetch failed", error);
           return Promise.reject(error);
         });
       }
@@ -459,7 +447,7 @@ function carelinkSource (opts, axios) {
         if (!enabled) {
           return enabled;
         }
-        console.log("SHOULD FETCH PATIENT LIST?", enabled, account.user.role, account.user.role == 'PATIENT_OUS');
+        log.debug("CareLink patient selection started");
         var acceptable = [null, 'PATIENT', 'PATIENT_US', 'PATIENT_OUS' ];
         if (acceptable.indexOf(account.user.role) > 0) {
 
@@ -469,11 +457,11 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.patient_list_url, { headers }).then((resp) => {
-          console.log("PATIENT LIST", resp.data);
+          log.debug("CareLink patient list fetched");
           account.patient_list = resp.data;
           return resp.data;
         }).catch((error) => {
-          console.log("ERROR FETCHING M2M LIST", error.response.headers, error.response.data);
+          log.error("CareLink patient list fetch failed", error);
         });
 
       }
@@ -481,7 +469,7 @@ function carelinkSource (opts, axios) {
       function summarize ( ) {
         var inputs = [getUser( ).then(getM2M).then(fetchPatientList), getProfile( ), getCountrySettings( ) ];
         return Promise.allSettled(inputs).then((results) => {
-          console.log("FINAL", results);
+          log.debug("CareLink session requests completed");
           var fulfilled = results.filter((result) => 'fulfilled' == result.status);
           if (fulfilled.length < inputs.length) {
             return Promise.reject(new Error("unable to fulfill session specifications"));
@@ -524,10 +512,10 @@ function carelinkSource (opts, axios) {
           return Promise.resolve(new Error("no patientUsername"));
         }
         return http.get(modDefaults.m2m_data_url + session.patientUsername, { params, headers }).then((resp) => {
-          console.log("DATA", resp.headers, resp.data);
+          log.debug("CareLink patient data fetched");
           return resp.data;
         }).catch((error) => {
-          console.log("ERROR DATA FETCH", error);
+          log.error("CareLink patient data fetch failed", error);
           return Promise.reject(error);
         });
       }
@@ -549,10 +537,10 @@ function carelinkSource (opts, axios) {
         }
         // if (session.isPatient) { return Promise.resolve( ); }
         return http.post(session.requirements.blePereodicDataEndpoint, body, { headers }).then((resp) => {
-          console.log("BLE PERIODIC ENDPOINT DATA", resp.headers, resp.data);
+          log.debug("CareLink periodic data fetched");
           return resp.data;
         }).catch((error) => {
-          console.log("BLE PERIODIC ENDPOINT ERROR", error, error.response ? error.response.headers : "", error.response ? error.response.data : "");
+          log.error("CareLink periodic data fetch failed", error);
           return Promise.reject(error);
         });
       }
@@ -565,10 +553,10 @@ function carelinkSource (opts, axios) {
         };
         return http.get(modDefaults.monitor_data_url, { headers }).then((resp) => {
 
-          console.log("MONITOR DATA ENDPOINT DATA", resp.headers, resp.data);
+          log.debug("CareLink monitor data fetched");
           return resp.data;
         }).catch((error) => {
-          console.log("MONITOR DATA ENDPOINT ERROR", error, error.response ? error.response.headers : "", error.response ? error.response.data : "");
+          log.error("CareLink monitor data fetch failed", error);
           return Promise.reject(error);
         });
       }
@@ -581,16 +569,16 @@ function carelinkSource (opts, axios) {
         ...authed_headers
         };
         return http.get(modDefaults.recent_uploads_url, { params, headers }).then((resp) => {
-          console.log("RECENT UPLOADS DATA", resp.headers, resp.data);
+          log.debug("CareLink recent uploads fetched");
           return resp.data;
         }).catch((error) => {
-          console.log("RECENT UPLOADS ERROR", error, error.response ? error.response.headers : "", error.response ? error.response.data : "");
+          log.error("CareLink recent uploads fetch failed", error);
           return Promise.reject(error);
         });
       }
 
       function fetch_payload ({ deviceFamily }) {
-        console.log("SELECTING PAYLOAD FETCH FOR ", deviceFamily);
+        log.debug("CareLink data endpoint selected");
         if (deviceFamily == 'GUARDIAN') {
           return m2m_data( );
         }
@@ -598,7 +586,7 @@ function carelinkSource (opts, axios) {
       }
 
       function summarize (results) {
-        console.log("RESULTS", results);
+        log.debug("CareLink data requests completed");
         // return result that has sgs
         var outputs = results
           .filter(({status, value: payload }) => status == 'fulfilled' && payload && payload.sgs)
@@ -619,7 +607,7 @@ function carelinkSource (opts, axios) {
       return Promise.allSettled(inputs).then(summarize);
     },
     refreshSession (authInfo, session) {
-      console.log("REFRESH REFRESH REFRESH", authInfo, session);
+      log.debug("CareLink token refresh started");
       var authed_headers = {
         Authorization: `Bearer ${session.token}`
       };
@@ -632,26 +620,20 @@ function carelinkSource (opts, axios) {
         , locale: opts.languageCode
       };
       return http.post(modDefaults.refresh_token_url, {},  { params, headers }).then((resp) => {
-        console.log("SUCCESS WITH REFRESH FOR", resp.headers, resp.data);
+        log.debug("CareLink token refresh completed");
         var cookies = jar.getCookiesSync(baseURL);
-        console.log("COOKIES", cookies);
-        var token = cookies.filter((c) => { console.log(c); return c.key == modDefaults.cookies.token; }).pop( )?.value;
-        var expires = cookies.filter((c) => { console.log(c); return c.key == modDefaults.cookies.recency; }).pop( )?.value;
+        var token = cookies.filter((c) => { return c.key == modDefaults.cookies.token; }).pop( )?.value;
+        var expires = cookies.filter((c) => { return c.key == modDefaults.cookies.recency; }).pop( )?.value;
         // authInfo.token = token;
         // authInfo.expires = expires;
-        console.log("REFRESHING TOKEN?", token, expires, token && expires);
+        log.debug("CareLink token cookies checked");
         if (token && expires) {
           session.token = token;
           session.expires = expires;
         }
         return session;
       }).catch((error) => {
-        console.log("ERROR REFRESHING TOKEN!!");
-        if (error.response) {
-          console.log("REFRESH ERROR", error.response.headers, error.response.data);
-        } else {
-          console.error(error);
-        }
+        log.error("CareLink token refresh failed", error);
 
         return Promise.reject(error);
       });
@@ -665,7 +647,7 @@ function carelinkSource (opts, axios) {
       var last_glucose_at = last_known.entries;
       var missing = ((new Date( )).getTime( ) - last_glucose_at.getTime( )) / (1000 * 60 * 5)
       if (missing > 1 && missing < 3) {
-        console.log("READJUSTING SHOULD MAKE A DIFFERENCE MISSING", missing);
+        log.debug("CareLink polling schedule adjusted");
 
       }
       var next_due = last_glucose_at.getTime( ) + (Math.ceil(missing) * 1000 * 60 * 5);
@@ -675,7 +657,7 @@ function carelinkSource (opts, axios) {
       return align_to;
     },
     transformPayload (data, last_known) {
-      console.log("INCOMING DATA", last_known, data);
+      log.debug("CareLink data transformation started");
       if (!data || !data.medicalDeviceFamily) {
         return { entries: [ ] };
       }
@@ -757,9 +739,7 @@ function carelinkSource (opts, axios) {
       var treatments = markers_to_treatment(markers)
         .filter(is_recent_treatment);
 
-      console.log("INCOMING TALLY SGS", data.sgs.length, 'reduced', entries.length);
-      console.log("INCOMING TALLY TREATMENTS", data.markers.length, 'reduced', treatments.length);
-      console.log("INCOMING DEVICESTATUS", deviceStatus);
+      log.debug("CareLink data transformed");
       return { entries, devicestatus, treatments };
     }
   };

--- a/lib/sources/nightscout.js
+++ b/lib/sources/nightscout.js
@@ -1,3 +1,4 @@
+var createLogger = require('../logging');
 
 // var qs = require('querystring');
 var qs = require('qs');
@@ -14,7 +15,8 @@ function encode_api_secret(plain) {
 }
 
 
-function nightscoutSource (opts, axios) {
+function nightscoutSource (opts, axios, log) {
+  log = log || createLogger(opts.debug);
 
   var endpoint = url.parse(opts.url);
   var baseURL = url.format({
@@ -30,7 +32,7 @@ function nightscoutSource (opts, axios) {
   // into Authorization: Bearer <jwt>
   // if (params.token) { }
 
-  console.log("NIGHTSCOUT BASE URL", baseURL);
+  log.debug("Nightscout source configured");
   var default_headers = {
     'User-Agent': user_agent_string
   };
@@ -55,7 +57,7 @@ function nightscoutSource (opts, axios) {
   function fetchCollection (session, last_known, collection, path, field) {
     var since = sinceFor(last_known, collection);
     var query = { find: { [field]: { $gt: since.toISOString( ) } }, count: sourceMaxCount };
-    console.log("FETCHING NIGHTSCOUT COLLECTION", collection, path, query);
+    log.debug("Nightscout collection requested");
     return http.get(path, { params: query, headers: authHeaders(session) }).then((resp) => resp.data || [ ]);
   }
   function fetchProfiles (session) {
@@ -101,9 +103,9 @@ function nightscoutSource (opts, axios) {
       // prefer using a token for traceability reasons
       if (params.token) return Promise.resolve(params.token);
       // check if it's already readable
-      console.log("CHECKING", http, checkURL);
+      log.debug("Checking Nightscout read permission");
       return http.get(checkURL).then((resp) => {
-        console.log("CHECKED", checkURL, resp);
+        log.debug("Nightscout read permission checked");
         var checked = resp.data;
         if (checked.status == 200 && checked.message.canRead) {
           return Promise.resolve({ readable: checked });
@@ -115,7 +117,7 @@ function nightscoutSource (opts, axios) {
         return getOrCreateReaderToken( );
 
       }).catch((err) => {
-        console.log("CHECKED SOMETHING WRONG", err && err.message);
+        log.error("Nightscout read permission check failed", err);
         if (apiSecret) {
           return getOrCreateReaderToken( );
         }
@@ -143,7 +145,7 @@ function nightscoutSource (opts, axios) {
       });
     },
     align_to_glucose (last_known) {
-      console.log("INSIDE NIGHTSCOUT SOURCE DRIVER ALIGNMENT FOR GLUCOSE");
+      log.debug("Aligning Nightscout polling schedule");
       if (!last_known || !last_known.entries) {
         return;
       }
@@ -151,7 +153,7 @@ function nightscoutSource (opts, axios) {
       var last_glucose_at = last_known.entries;
       var missing = ((new Date( )).getTime( ) - last_glucose_at.getTime( )) / (1000 * 60 * 5)
       if (missing > 1 && missing < 3) {
-        console.log("READJUSTING SHOULD MAKE A DIFFERENCE MISSING", missing);
+        log.debug("Nightscout polling schedule adjusted");
 
       }
       var next_due = last_glucose_at.getTime( ) + (Math.ceil(missing) * 1000 * 60 * 5);

--- a/test/logging.test.js
+++ b/test/logging.test.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { EventEmitter } = require('node:events');
+const { inspect } = require('node:util');
+const { setImmediate: immediate, setTimeout: delay } = require('node:timers/promises');
+const { interpret } = require('xstate');
+const createLogger = require('../lib/logging');
+const connect = require('../');
+const builder = require('../lib/builder');
+const dexcom = require('../lib/sources/dexcomshare');
+const internal = require('../lib/outputs/internal');
+
+const secret = 'private-credential-and-patient-marker';
+const credentials = { source: 'dexcomshare', shareAccountName: secret, sharePassword: secret };
+function capture(t) {
+  const calls = [];
+  for (const method of ['log', 'info', 'debug', 'warn', 'error']) {
+    t.mock.method(console, method, (...args) => calls.push({ method, text: inspect(args, { depth: 20 }) }));
+  }
+  return calls;
+}
+function safe(calls) {
+  assert.ok(!calls.some(call => call.text.includes(secret)), 'private data reached a log');
+}
+function failure() {
+  const error = new Error(secret);
+  error.response = { status: 401, data: secret, headers: { Authorization: secret } };
+  error.config = { data: secret };
+  return error;
+}
+
+for (const value of [undefined, false, 'false', 'off', '', 'invalid', '1', 1, true, 'true', 'ON', ' true ']) {
+  test('debug setting is opt-in: ' + JSON.stringify(value), t => {
+    const calls = capture(t);
+    const log = createLogger(value);
+    log.debug('Data loaded');
+    const expected = [true, 'true', 'ON', ' true '].includes(value);
+    assert.equal(calls.length, expected ? 1 : 0);
+    log.warn('Configuration needs attention');
+    log.error('Authentication failed', failure());
+    assert.equal(calls.at(-2).method, 'warn');
+    assert.match(calls.at(-1).text, /Authentication failed.*HTTP 401/);
+    safe(calls);
+  });
+}
+
+test('non-numeric remote status is not printed', t => {
+  const calls = capture(t);
+  const error = failure();
+  error.response.status = secret;
+  createLogger(true).error('Request failed', error);
+  safe(calls);
+  assert.equal(calls.length, 1);
+});
+
+for (const [globalDebug, override, expected] of [
+  [undefined, undefined, false], [true, undefined, true],
+  [false, true, true], [true, false, false], [true, 'invalid', false]
+]) {
+  test(`connector startup and data-loaded honor global=${globalDebug}, override=${override}`, async t => {
+    const calls = capture(t);
+    const ctx = { bus: new EventEmitter(), bootErrors: [] };
+    const settings = { ...credentials };
+    if (override !== undefined) settings.debug = override;
+    const handle = connect({ debug: { logging: globalDebug }, extendedSettings: { connect: settings } }, ctx);
+    try {
+      // Keep the real internal output listener, but don't start vendor I/O.
+      ctx.bus.removeListener('data-processed', handle.run);
+      const sg = { mills: Date.now(), sgv: 123, private: secret };
+      const sbx = { data: { sgvs: [sg], treatments: [], devicestatus: [], profile: [] }, lastEntry: items => items.at(-1) };
+      for (let i = 0; i < 10; i++) {
+        ctx.bus.emit('tick', { private: secret });
+        ctx.bus.emit('data-processed', sbx);
+      }
+      assert.equal(ctx.bus.listenerCount('tick'), 0);
+      assert.equal(calls.filter(call => call.text.includes('data-loaded')).length, expected ? 10 : 0);
+      assert.equal(calls.length > 0, expected);
+      safe(calls);
+    } finally { await handle.stop(); ctx.bus.removeAllListeners(); }
+  });
+}
+
+for (const debug of [false, true]) {
+  test(`internal persistence still writes and returns bookmarks with debug=${debug}`, async t => {
+    const calls = capture(t);
+    const bus = new EventEmitter();
+    const sg = { mills: Date.now(), sgv: 123, private: secret };
+    const sbx = { data: { sgvs: [sg], treatments: [], devicestatus: [], profile: [] }, lastEntry: items => items.at(-1) };
+    const written = {};
+    const ctx = { bus };
+    for (const kind of ['entries', 'treatments', 'devicestatus', 'profile']) {
+      ctx[kind] = { create(items, cb) { written[kind] = items; cb(null, items); setImmediate(() => bus.emit('data-processed', sbx)); } };
+    }
+    const output = internal({ debug }, ctx);
+    try {
+      const gap = output.gap_for();
+      bus.emit('data-processed', sbx);
+      assert.equal((await gap).sgvs, sg);
+      const batch = { entries: [sg], treatments: [{ private: secret }], devicestatus: [{ private: secret }], profiles: [{ private: secret }] };
+      assert.equal((await output(batch)).sgvs, sg);
+      for (const kind of ['entries', 'treatments', 'devicestatus']) assert.equal(written[kind], batch[kind]);
+      assert.equal(written.profile, batch.profiles);
+      await immediate();
+      assert.equal(calls.length > 0, debug);
+      safe(calls);
+      ctx.entries.create = (items, cb) => cb(failure());
+      await output({ entries: [sg] });
+      assert.ok(calls.some(call => call.method === 'error' && call.text.includes('Internal persistence failed')));
+    } finally { bus.removeAllListeners(); }
+  });
+
+  for (const fail of [false, true]) {
+    test(`real polling actors preserve success/failure with debug=${debug}, failure=${fail}`, async t => {
+      const calls = capture(t);
+      let persisted = 0;
+      let rejected = 0;
+      const log = createLogger(debug);
+      const post = async url => {
+        if (fail) { rejected++; throw failure(); }
+        if (url.includes('Authenticate')) return { data: { accountId: secret } };
+        if (url.includes('Login')) return { data: secret };
+        return { data: [{ WT: `/Date(${Date.now()})/`, Value: 123, Trend: 4 }] };
+      };
+      const output = async batch => { assert.equal(batch.entries[0].sgv, 123); persisted++; return { entries: new Date() }; };
+      output.gap_for = async () => ({ entries: new Date(Date.now() - 300000) });
+      const make = builder({ output, logger: log });
+      dexcom(credentials, { create: () => ({ post }) }, log).generate_driver(make);
+      const actor = interpret(make());
+      try {
+        actor.start(); actor.send('START');
+        for (let i = 0; i < 100 && !(fail ? rejected : persisted); i++) await delay(5);
+        await immediate();
+        assert.ok(fail ? rejected : persisted);
+        actor.send({ type: 'DEBUG', data: secret });
+        actor.children.get('Session').send({ type: 'DEBUG', data: secret });
+        assert.equal(calls.some(call => call.method === 'debug'), debug);
+        assert.equal(calls.some(call => call.method === 'error'), fail);
+        if (!debug && !fail) assert.equal(calls.length, 0, inspect(calls));
+        assert.equal(fail ? actor.state.context.authentication_errors : actor.state.context.sessions, 1);
+        safe(calls);
+      } finally { actor.stop(); }
+    });
+  }
+}
+
+test('invalid configuration remains visible without debugging', t => {
+  const calls = capture(t);
+  const ctx = { bus: new EventEmitter(), bootErrors: [] };
+  try {
+    assert.equal(connect({ extendedSettings: { connect: { source: 'dexcomshare', sharePassword: secret } } }, ctx), undefined);
+    assert.ok(ctx.bootErrors.length > 0);
+    assert.ok(calls.some(call => call.method === 'error' && call.text.includes('Invalid configuration')));
+    safe(calls);
+  } finally { ctx.bus.removeAllListeners(); }
+});
+
+for (const debug of [false, true]) {
+  test(`provider summaries protect authentication/session payloads with debug=${debug}`, async t => {
+    const calls = capture(t);
+    const log = createLogger(debug);
+    const libre = require('../lib/sources/librelinkup')({}, {
+      create: () => ({
+        post: async () => ({ data: { data: { authTicket: { token: secret } } }, headers: { private: secret } }),
+        get: async () => ({ data: { data: [{ patientId: secret }] }, headers: { private: secret } })
+      })
+    }, log);
+    const auth = await libre.authFromCredentials();
+    const session = await libre.sessionFromAuth(auth);
+    assert.equal(session.patientId, secret);
+    assert.equal(session.authTicket.token, secret);
+    const glooko = require('../lib/sources/glooko')({ baseURL: 'https://example.invalid', glookoServer: 'example.invalid', glookoAuthMode: 'api' }, {
+      create: () => ({ post: async () => ({ data: { user: secret }, headers: { 'set-cookie': [secret] } }) })
+    }, log);
+    assert.equal((await glooko.authFromCredentials()).user.user, secret);
+    const nightscout = require('../lib/sources/nightscout')({ url: 'https://example.invalid', apiSecret: secret }, {
+      create: () => ({ get: async () => ({ data: { status: 200, message: { canRead: true, private: secret } } }) })
+    }, log);
+    assert.equal((await nightscout.authFromCredentials()).readable.message.private, secret);
+    assert.equal(calls.some(call => call.method === 'debug'), debug);
+    if (!debug) assert.equal(calls.length, 0);
+    safe(calls);
+  });
+
+  test(`CareLink login and refresh retain results with debug=${debug}`, async t => {
+    const calls = capture(t);
+    const axios = require('axios');
+    const form = '<form action="/login" method="POST">\n<input type="hidden" name="sessionID" value="' + secret + '">\n<input type="hidden" name="sessionData" value="' + secret + '">';
+    const client = axios.create({ adapter: async config => {
+      config.jar.setCookieSync('auth_tmp_token=' + secret + '; Path=/', config.baseURL);
+      config.jar.setCookieSync('c_token_valid_to=' + secret + '; Path=/', config.baseURL);
+      return { data: form, status: 200, statusText: 'OK', config, headers: { private: secret, 'set-cookie': [secret + '=cookie; Path=/'] } };
+    } });
+    const source = require('../lib/sources/minimedcarelink')({
+      carelinkServer: 'example.invalid', carelinkUsername: secret, carelinkPassword: secret
+    }, client, createLogger(debug));
+    const auth = await source.authFromCredentials();
+    assert.equal(auth.token, secret);
+    const session = { token: secret };
+    assert.equal(await source.refreshSession(auth, session), session);
+    assert.equal(session.expires, secret);
+    assert.equal(calls.some(call => call.method === 'debug'), debug);
+    if (!debug) assert.equal(calls.length, 0);
+    safe(calls);
+  });
+}


### PR DESCRIPTION
Embedded Nightscout Connect currently logs every heartbeat and data update, dumps session/patient objects, and prints successful polling transitions. This contributes to Heroku log-quota exhaustion reported in nightscout/cgm-remote-monitor#8714.

Make routine embedded-plugin diagnostics opt-in with `CONNECT_DEBUG=true`. When no connector override is set, inherit Nightscout's `env.debug.logging` setting; otherwise default to quiet. Keep warnings, configuration errors and polling/provider failures visible, with fixed operation labels and numeric HTTP status codes. Pass one logger through the provider, internal output and polling machines without changing the global console. Replace optional capture actions with no-ops when capture is disabled, preventing per-cycle missing-action warnings. CLI output targets and explicit HAR capture are outside this setting.

Validation:
- All 76 tests pass on Node 20.19.6, 22.23.2 and 24.20.0, including 29 new logging regressions.
- Actual polling actors, internal persistence, all five embedded providers, configuration failures and debug overrides are exercised with fixture credentials; no live vendor requests.
- Ten heartbeat/data-processed pairs: v0.0.13 produced 20 calls / 80 lines / 2,629 bytes; quiet mode produces none; debug mode produces 10 lines / 379 bytes. This is a controlled reproduction, not a production quota guarantee.

Consumed by [cgm-remote-monitor#8726](https://github.com/nightscout/cgm-remote-monitor/pull/8726), targeting dev and pinning this exact commit. This branch starts from connector dev and changes logging only; it does not incorporate the unrelated source-contract/lifecycle changes from #64 or #66. There is overlap with their logging edits to reconcile when those branches merge.
